### PR TITLE
fix: handle unknown Terraform state attributes during decode

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -284,12 +284,185 @@ func getResourceState(resInstance *states.ResourceInstance, rType string,
 		return cty.NilVal, err
 	}
 
-	resInstanceObj, err := resInstance.Current.Decode(resourceSchema.Block.ImpliedType())
+	resInstanceObj, filteredUnknownAttrs, err := decodeResourceInstanceObject(
+		resInstance, resourceSchema.Block.ImpliedType())
 	if err != nil {
 		return cty.NilVal, err
 	}
 
+	if filteredUnknownAttrs {
+		log.WithField("type", rType).Debug(internal.Pad("ignored unknown attributes in resource state"))
+	}
+
 	return resInstanceObj.Value, nil
+}
+
+func decodeResourceInstanceObject(
+	resInstance *states.ResourceInstance, schemaType cty.Type) (*states.ResourceInstanceObject, bool, error) {
+	resInstanceObj, err := resInstance.Current.Decode(schemaType)
+	if err == nil {
+		return resInstanceObj, false, nil
+	}
+
+	if resInstance.Current.AttrsJSON == nil {
+		return nil, false, err
+	}
+
+	attrsJSONPruned, changed, pruneErr := pruneUnknownAttributesFromJSON(resInstance.Current.AttrsJSON, schemaType)
+	if pruneErr != nil || !changed {
+		return nil, false, err
+	}
+
+	current := *resInstance.Current
+	current.AttrsJSON = attrsJSONPruned
+
+	resInstanceObj, decodeErr := current.Decode(schemaType)
+	if decodeErr != nil {
+		return nil, false, err
+	}
+
+	return resInstanceObj, true, nil
+}
+
+func pruneUnknownAttributesFromJSON(attrsJSON []byte, schemaType cty.Type) ([]byte, bool, error) {
+	var raw any
+
+	err := json.Unmarshal(attrsJSON, &raw)
+	if err != nil {
+		return nil, false, err
+	}
+
+	pruned, changed := pruneUnknownAttributes(raw, schemaType)
+	if !changed {
+		return attrsJSON, false, nil
+	}
+
+	prunedJSON, err := json.Marshal(pruned)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return prunedJSON, true, nil
+}
+
+func pruneUnknownAttributes(raw any, schemaType cty.Type) (any, bool) {
+	if raw == nil || schemaType == cty.DynamicPseudoType {
+		return raw, false
+	}
+
+	if schemaType.IsObjectType() {
+		return pruneUnknownObjectAttributes(raw, schemaType)
+	}
+
+	if schemaType.IsMapType() {
+		return pruneUnknownMapAttributes(raw, schemaType.ElementType())
+	}
+
+	if schemaType.IsListType() || schemaType.IsSetType() {
+		return pruneUnknownListAttributes(raw, schemaType.ElementType())
+	}
+
+	if schemaType.IsTupleType() {
+		return pruneUnknownTupleAttributes(raw, schemaType.TupleElementTypes())
+	}
+
+	return raw, false
+}
+
+func pruneUnknownObjectAttributes(raw any, schemaType cty.Type) (any, bool) {
+	rawObject, ok := raw.(map[string]any)
+	if !ok {
+		return raw, false
+	}
+
+	attrTypes := schemaType.AttributeTypes()
+	prunedObject := make(map[string]any, len(rawObject))
+	changed := false
+
+	for key, value := range rawObject {
+		attrType, ok := attrTypes[key]
+		if !ok {
+			changed = true
+			continue
+		}
+
+		prunedValue, valueChanged := pruneUnknownAttributes(value, attrType)
+		if valueChanged {
+			changed = true
+		}
+
+		prunedObject[key] = prunedValue
+	}
+
+	return prunedObject, changed
+}
+
+func pruneUnknownMapAttributes(raw any, elemType cty.Type) (any, bool) {
+	rawMap, ok := raw.(map[string]any)
+	if !ok {
+		return raw, false
+	}
+
+	prunedMap := make(map[string]any, len(rawMap))
+	changed := false
+
+	for key, value := range rawMap {
+		prunedValue, valueChanged := pruneUnknownAttributes(value, elemType)
+		if valueChanged {
+			changed = true
+		}
+
+		prunedMap[key] = prunedValue
+	}
+
+	return prunedMap, changed
+}
+
+func pruneUnknownListAttributes(raw any, elemType cty.Type) (any, bool) {
+	rawList, ok := raw.([]any)
+	if !ok {
+		return raw, false
+	}
+
+	prunedList := make([]any, len(rawList))
+	changed := false
+
+	for idx, value := range rawList {
+		prunedValue, valueChanged := pruneUnknownAttributes(value, elemType)
+		if valueChanged {
+			changed = true
+		}
+
+		prunedList[idx] = prunedValue
+	}
+
+	return prunedList, changed
+}
+
+func pruneUnknownTupleAttributes(raw any, elemTypes []cty.Type) (any, bool) {
+	rawTuple, ok := raw.([]any)
+	if !ok {
+		return raw, false
+	}
+
+	prunedTuple := make([]any, len(rawTuple))
+	changed := false
+
+	for idx, value := range rawTuple {
+		elemType := cty.DynamicPseudoType
+		if idx < len(elemTypes) {
+			elemType = elemTypes[idx]
+		}
+
+		prunedValue, valueChanged := pruneUnknownAttributes(value, elemType)
+		if valueChanged {
+			changed = true
+		}
+
+		prunedTuple[idx] = prunedValue
+	}
+
+	return prunedTuple, changed
 }
 
 // copied (and modified) from github.com/hashicorp/terraform/command/state_meta.go

--- a/pkg/state/state_compat_test.go
+++ b/pkg/state/state_compat_test.go
@@ -1,0 +1,63 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/states"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestDecodeResourceInstanceObject_UnknownAttributeCompatibility(t *testing.T) {
+	schemaType := cty.Object(map[string]cty.Type{
+		"id": cty.String,
+		"default_action": cty.List(cty.Object(map[string]cty.Type{
+			"type": cty.String,
+		})),
+	})
+
+	resInstance := states.NewResourceInstance()
+	resInstance.Current = &states.ResourceInstanceObjectSrc{
+		AttrsJSON: []byte(`{
+			"id":"listener-123",
+			"default_action":[{"type":"forward"}],
+			"mutual_authentication":[{"mode":"off"}]
+		}`),
+	}
+
+	_, strictDecodeErr := resInstance.Current.Decode(schemaType)
+	require.Error(t, strictDecodeErr)
+	assert.Contains(t, strictDecodeErr.Error(), `unsupported attribute "mutual_authentication"`)
+
+	resInstanceObj, filteredUnknownAttrs, err := decodeResourceInstanceObject(resInstance, schemaType)
+	require.NoError(t, err)
+	require.NotNil(t, resInstanceObj)
+	assert.True(t, filteredUnknownAttrs)
+	assert.Equal(t, cty.StringVal("listener-123"), resInstanceObj.Value.GetAttr("id"))
+
+	attrs := resInstanceObj.Value.Type().AttributeTypes()
+	_, hasMutualAuthentication := attrs["mutual_authentication"]
+	assert.False(t, hasMutualAuthentication)
+}
+
+func TestPruneUnknownAttributesFromJSON_PreservesMapEntries(t *testing.T) {
+	schemaType := cty.Object(map[string]cty.Type{
+		"id":   cty.String,
+		"tags": cty.Map(cty.String),
+	})
+
+	attrsJSON := []byte(`{
+		"id":"listener-123",
+		"tags":{"managed_by":"Terraform"},
+		"mutual_authentication":[{"mode":"off"}]
+	}`)
+
+	prunedJSON, changed, err := pruneUnknownAttributesFromJSON(attrsJSON, schemaType)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.JSONEq(t, `{
+		"id":"listener-123",
+		"tags":{"managed_by":"Terraform"}
+	}`, string(prunedJSON))
+}


### PR DESCRIPTION
## Summary
Fixes state decode failures for Terraform 1.x AWS states that include attributes unknown to the currently loaded provider schema (for example `aws_alb_listener.mutual_authentication`).

This keeps the current provider bootstrap (`aws` `v3.42.0`) but makes decode tolerant to forward-added state attributes.

## What changed
- added a compatibility decode path in `pkg/state/state.go`:
  - attempt strict decode first
  - on failure, prune unknown JSON attributes according to the schema type
  - retry decode with pruned attributes
- added debug logging when unknown attributes are ignored
- added regression tests in `pkg/state/state_compat_test.go`:
  - reproduces strict decode failure with `unsupported attribute "mutual_authentication"`
  - verifies compatibility path succeeds and preserves expected attributes
  - verifies map values (for example tags) are preserved while unknown object attrs are removed

## Reproduction
Before this change:
```bash
AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 go run . -debug -force /tmp/terradozer-repro-mutual-auth-state.json
```
failed with:
```text
failed to decode resource into object ... unsupported attribute "mutual_authentication"
```

After this change, decode proceeds and the command reaches provider read/refresh logic.

## Validation
- `go test ./pkg/state -run 'TestDecodeResourceInstanceObject_UnknownAttributeCompatibility|TestPruneUnknownAttributesFromJSON_PreservesMapEntries'`
- `go test -short ./...`
- `go vet ./...`
- `golangci-lint run`

Closes #22
