### PR TITLE
feat: bootstrap AWS provider v5.100.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,10 @@ import (
 	"github.com/jckuester/terradozer/internal"
 	"github.com/jckuester/terradozer/pkg/resource"
 	"github.com/jckuester/terradozer/pkg/state"
+	"github.com/zclconf/go-cty/cty"
 )
+
+const awsProviderBootstrapVersion = "v5.100.0"
 
 func main() {
 	os.Exit(mainExitCode())
@@ -105,7 +108,7 @@ func mainExitCode() int {
 	setAWSRegionFromDefault()
 	setAWSProfileToDefault()
 
-	providers, err := provider.InitProviders(tfstate.ProviderNames(), "~/.terradozer", timeoutDuration)
+	providers, err := initProviders(tfstate.ProviderNames(), "~/.terradozer", timeoutDuration)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("\nError:️ failed to initialize Terraform providers: %s\n", err))
 
@@ -189,6 +192,100 @@ func setAWSProfileToDefault() {
 	}
 
 	_ = os.Setenv("AWS_PROFILE", "default")
+}
+
+func initProviders(providerNames []string, installDir string,
+	timeout time.Duration) (map[string]*provider.TerraformProvider, error) {
+	providers := map[string]*provider.TerraformProvider{}
+
+	for _, providerName := range providerNames {
+		if providerName != "aws" {
+			log.WithField("name", providerName).Debug("ignoring resources of (yet) unsupported provider")
+			continue
+		}
+
+		p, err := initAWSProvider(installDir, timeout)
+		if err != nil {
+			return nil, err
+		}
+
+		providers[providerName] = p
+	}
+
+	return providers, nil
+}
+
+func initAWSProvider(installDir string, timeout time.Duration) (*provider.TerraformProvider, error) {
+	metaPlugin, err := provider.Install("aws", awsProviderBootstrapVersion, installDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install provider (aws): %w", err)
+	}
+
+	p, err := provider.Launch(metaPlugin.Path, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to launch provider (%s): %w", metaPlugin.Path, err)
+	}
+
+	err = p.Configure(awsProviderConfig())
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure provider (name=%s, version=%s): %w",
+			metaPlugin.Name, metaPlugin.Version, err)
+	}
+
+	log.WithFields(log.Fields{
+		"name":    metaPlugin.Name,
+		"version": metaPlugin.Version,
+	}).Debug("configured provider")
+
+	return p, nil
+}
+
+func awsProviderConfig() cty.Value {
+	config := map[string]cty.Value{
+		"access_key":                         cty.StringVal(os.Getenv("AWS_ACCESS_KEY_ID")),
+		"allowed_account_ids":                cty.UnknownVal(cty.DynamicPseudoType),
+		"assume_role":                        cty.UnknownVal(cty.DynamicPseudoType),
+		"assume_role_with_web_identity":      cty.UnknownVal(cty.DynamicPseudoType),
+		"custom_ca_bundle":                   cty.UnknownVal(cty.DynamicPseudoType),
+		"default_tags":                       cty.UnknownVal(cty.DynamicPseudoType),
+		"ec2_metadata_service_endpoint":      cty.UnknownVal(cty.DynamicPseudoType),
+		"ec2_metadata_service_endpoint_mode": cty.UnknownVal(cty.DynamicPseudoType),
+		"endpoints":                          cty.UnknownVal(cty.DynamicPseudoType),
+		"forbidden_account_ids":              cty.UnknownVal(cty.DynamicPseudoType),
+		"http_proxy":                         cty.UnknownVal(cty.DynamicPseudoType),
+		"https_proxy":                        cty.UnknownVal(cty.DynamicPseudoType),
+		"ignore_tags":                        cty.UnknownVal(cty.DynamicPseudoType),
+		"insecure":                           cty.UnknownVal(cty.DynamicPseudoType),
+		"max_retries":                        cty.UnknownVal(cty.DynamicPseudoType),
+		"no_proxy":                           cty.UnknownVal(cty.DynamicPseudoType),
+		"profile":                            cty.StringVal(os.Getenv("AWS_PROFILE")),
+		"region":                             cty.StringVal(os.Getenv("AWS_REGION")),
+		"retry_mode":                         cty.UnknownVal(cty.DynamicPseudoType),
+		"s3_us_east_1_regional_endpoint":     cty.UnknownVal(cty.DynamicPseudoType),
+		"s3_use_path_style":                  cty.UnknownVal(cty.DynamicPseudoType),
+		"secret_key":                         cty.StringVal(os.Getenv("AWS_SECRET_ACCESS_KEY")),
+		"shared_config_files":                cty.UnknownVal(cty.DynamicPseudoType),
+		"shared_credentials_files":           cty.UnknownVal(cty.DynamicPseudoType),
+		"skip_credentials_validation":        cty.UnknownVal(cty.DynamicPseudoType),
+		"skip_metadata_api_check":            cty.UnknownVal(cty.DynamicPseudoType),
+		"skip_region_validation":             cty.UnknownVal(cty.DynamicPseudoType),
+		"skip_requesting_account_id":         cty.UnknownVal(cty.DynamicPseudoType),
+		"sts_region":                         cty.UnknownVal(cty.DynamicPseudoType),
+		"token":                              cty.StringVal(os.Getenv("AWS_SESSION_TOKEN")),
+		"token_bucket_rate_limiter_capacity": cty.UnknownVal(cty.DynamicPseudoType),
+		"use_dualstack_endpoint":             cty.UnknownVal(cty.DynamicPseudoType),
+		"use_fips_endpoint":                  cty.UnknownVal(cty.DynamicPseudoType),
+	}
+
+	if sharedCredentialsFile := os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); sharedCredentialsFile != "" {
+		config["shared_credentials_files"] = cty.ListVal([]cty.Value{cty.StringVal(sharedCredentialsFile)})
+	}
+
+	if sharedConfigFile := os.Getenv("AWS_CONFIG_FILE"); sharedConfigFile != "" {
+		config["shared_config_files"] = cty.ListVal([]cty.Value{cty.StringVal(sharedConfigFile)})
+	}
+
+	return cty.ObjectVal(config)
 }
 
 func printHelp(fs *flag.FlagSet) {

--- a/main_test.go
+++ b/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestSetAWSRegionFromDefault(t *testing.T) {
@@ -72,5 +74,99 @@ func TestSetAWSProfileToDefault(t *testing.T) {
 
 			assert.Equal(t, tc.expectedAWSProfile, os.Getenv("AWS_PROFILE"))
 		})
+	}
+}
+
+func TestInitProvidersSkipsUnsupportedProviders(t *testing.T) {
+	p, err := initProviders([]string{"google"}, ".terradozer", 10*time.Second)
+	assert.NoError(t, err)
+	assert.Empty(t, p)
+}
+
+func TestAWSProviderConfig(t *testing.T) {
+	t.Run("sets supported fields from environment", func(t *testing.T) {
+		t.Setenv("AWS_ACCESS_KEY_ID", "key-id")
+		t.Setenv("AWS_PROFILE", "ci")
+		t.Setenv("AWS_REGION", "us-east-1")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+		t.Setenv("AWS_CONFIG_FILE", "/tmp/config")
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/tmp/credentials")
+		t.Setenv("AWS_SESSION_TOKEN", "token")
+
+		config := awsProviderConfig().AsValueMap()
+
+		assert.True(t, config["access_key"].RawEquals(cty.StringVal("key-id")))
+		assert.True(t, config["profile"].RawEquals(cty.StringVal("ci")))
+		assert.True(t, config["region"].RawEquals(cty.StringVal("us-east-1")))
+		assert.True(t, config["secret_key"].RawEquals(cty.StringVal("secret")))
+		assert.True(t, config["shared_config_files"].RawEquals(
+			cty.ListVal([]cty.Value{cty.StringVal("/tmp/config")})))
+		assert.True(t, config["shared_credentials_files"].RawEquals(
+			cty.ListVal([]cty.Value{cty.StringVal("/tmp/credentials")})))
+		assert.True(t, config["token"].RawEquals(cty.StringVal("token")))
+	})
+
+	t.Run("uses unknown defaults when optional values are unset", func(t *testing.T) {
+		t.Setenv("AWS_ACCESS_KEY_ID", "")
+		t.Setenv("AWS_PROFILE", "")
+		t.Setenv("AWS_REGION", "")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+		t.Setenv("AWS_CONFIG_FILE", "")
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+		t.Setenv("AWS_SESSION_TOKEN", "")
+
+		config := awsProviderConfig().AsValueMap()
+
+		assert.True(t, config["access_key"].RawEquals(cty.StringVal("")))
+		assert.True(t, config["profile"].RawEquals(cty.StringVal("")))
+		assert.True(t, config["region"].RawEquals(cty.StringVal("")))
+		assert.True(t, config["secret_key"].RawEquals(cty.StringVal("")))
+		assert.True(t, config["token"].RawEquals(cty.StringVal("")))
+		assert.False(t, config["shared_config_files"].IsKnown())
+		assert.False(t, config["shared_credentials_files"].IsKnown())
+	})
+}
+
+func TestAWSProviderV5BootstrapContract(t *testing.T) {
+	assert.Equal(t, "v5.100.0", awsProviderBootstrapVersion)
+
+	requiredKeys := []string{
+		"access_key",
+		"allowed_account_ids",
+		"assume_role",
+		"assume_role_with_web_identity",
+		"custom_ca_bundle",
+		"default_tags",
+		"ec2_metadata_service_endpoint",
+		"ec2_metadata_service_endpoint_mode",
+		"endpoints",
+		"forbidden_account_ids",
+		"http_proxy",
+		"https_proxy",
+		"ignore_tags",
+		"insecure",
+		"max_retries",
+		"no_proxy",
+		"retry_mode",
+		"s3_us_east_1_regional_endpoint",
+		"s3_use_path_style",
+		"secret_key",
+		"shared_config_files",
+		"shared_credentials_files",
+		"skip_credentials_validation",
+		"skip_metadata_api_check",
+		"skip_region_validation",
+		"skip_requesting_account_id",
+		"sts_region",
+		"token",
+		"token_bucket_rate_limiter_capacity",
+		"use_dualstack_endpoint",
+		"use_fips_endpoint",
+	}
+
+	config := awsProviderConfig().AsValueMap()
+	for _, key := range requiredKeys {
+		_, ok := config[key]
+		assert.Truef(t, ok, "expected key %q in aws provider bootstrap config", key)
 	}
 }


### PR DESCRIPTION
## Summary
- switch terradozer provider initialization from awstools-lib defaults to a terradozer-managed bootstrap path
- pin AWS provider bootstrap version to `v5.100.0`
- configure the AWS provider using the v5-required config object shape while preserving env-based credentials/region/profile behavior
- add unit tests for v5 bootstrap contract and config mapping

## Validation
- `go generate ./...`
- `go test -short ./...`
- `go vet ./...`
- `golangci-lint run`
- smoke run:
  - `AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 AWS_EC2_METADATA_DISABLED=true go run . -debug -force test/test-fixtures/tfstates/version4-tf19-provider.json`
  - output includes: `configured provider name=aws version=5.100.0`
