### PR TITLE
feat: include runtime build metadata in version output

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -1,28 +1,71 @@
 package internal
 
 import (
+	"fmt"
 	"runtime"
+	"runtime/debug"
+	"strings"
 )
 
 //nolint:gochecknoglobals
 var (
-	version = "dev"
-	commit  = "?"
-	date    = "?"
+	version       = "dev"
+	commit        = "?"
+	date          = "?"
+	readBuildInfo = debug.ReadBuildInfo
 )
 
 func BuildVersionString() string {
-	result := "version: " + version
+	currentVersion, currentCommit, currentDate := buildMetadata()
 
-	if commit != "" {
-		result += "\ncommit: " + commit
+	return fmt.Sprintf(
+		"version: %s\ncommit: %s\nbuilt at: %s\nusing: %s",
+		currentVersion, currentCommit, currentDate, runtime.Version(),
+	)
+}
+
+func buildMetadata() (string, string, string) {
+	currentVersion := normalizeValue(version, "dev")
+	currentCommit := normalizeValue(commit, "?")
+	currentDate := normalizeValue(date, "?")
+
+	settings := buildInfoSettings()
+
+	if isUnsetValue(currentCommit) {
+		currentCommit = normalizeValue(settings["vcs.revision"], currentCommit)
 	}
 
-	if date != "" {
-		result += "\nbuilt at: " + date
+	if isUnsetValue(currentDate) {
+		currentDate = normalizeValue(settings["vcs.time"], currentDate)
 	}
 
-	result += "\nusing: " + runtime.Version()
+	return currentVersion, currentCommit, currentDate
+}
 
-	return result
+func buildInfoSettings() map[string]string {
+	info, ok := readBuildInfo()
+	if !ok || info == nil {
+		return nil
+	}
+
+	settings := make(map[string]string, len(info.Settings))
+	for _, setting := range info.Settings {
+		settings[setting.Key] = setting.Value
+	}
+
+	return settings
+}
+
+func normalizeValue(value, fallback string) string {
+	if isUnsetValue(value) {
+		return fallback
+	}
+
+	return strings.TrimSpace(value)
+}
+
+func isUnsetValue(value string) bool {
+	trimmedValue := strings.TrimSpace(value)
+
+	return trimmedValue == "" || trimmedValue == "?"
 }

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -1,15 +1,86 @@
-package internal_test
+package internal
 
 import (
 	"runtime"
+	"runtime/debug"
 	"testing"
 
-	"github.com/jckuester/terradozer/internal"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildVersionString(t *testing.T) {
-	actualVersionString := internal.BuildVersionString()
+func TestBuildVersionString_UsesRuntimeBuildInfoWhenLdflagsAreUnset(t *testing.T) {
+	resetBuildMetadata(t)
 
-	assert.Equal(t, actualVersionString, "version: dev\ncommit: ?\nbuilt at: ?\nusing: "+runtime.Version())
+	version = "dev"
+	commit = "?"
+	date = "?"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abc123def456"},
+				{Key: "vcs.time", Value: "2026-02-26T00:00:00Z"},
+			},
+		}, true
+	}
+
+	assert.Equal(
+		t,
+		"version: dev\ncommit: abc123def456\nbuilt at: 2026-02-26T00:00:00Z\nusing: "+runtime.Version(),
+		BuildVersionString(),
+	)
+}
+
+func TestBuildVersionString_PrefersLdflagsValuesOverRuntimeBuildInfo(t *testing.T) {
+	resetBuildMetadata(t)
+
+	version = "v0.2.0"
+	commit = "fa1f598"
+	date = "2026-02-26T20:00:00Z"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "should-not-be-used"},
+				{Key: "vcs.time", Value: "1970-01-01T00:00:00Z"},
+			},
+		}, true
+	}
+
+	assert.Equal(
+		t,
+		"version: v0.2.0\ncommit: fa1f598\nbuilt at: 2026-02-26T20:00:00Z\nusing: "+runtime.Version(),
+		BuildVersionString(),
+	)
+}
+
+func TestBuildVersionString_FallsBackToDefaultsWhenBuildInfoUnavailable(t *testing.T) {
+	resetBuildMetadata(t)
+
+	version = "dev"
+	commit = "?"
+	date = "?"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return nil, false
+	}
+
+	assert.Equal(
+		t,
+		"version: dev\ncommit: ?\nbuilt at: ?\nusing: "+runtime.Version(),
+		BuildVersionString(),
+	)
+}
+
+func resetBuildMetadata(t *testing.T) {
+	t.Helper()
+
+	previousVersion := version
+	previousCommit := commit
+	previousDate := date
+	previousReadBuildInfo := readBuildInfo
+
+	t.Cleanup(func() {
+		version = previousVersion
+		commit = previousCommit
+		date = previousDate
+		readBuildInfo = previousReadBuildInfo
+	})
 }

--- a/test/acc_test.go
+++ b/test/acc_test.go
@@ -185,11 +185,10 @@ func TestAcc_Version(t *testing.T) {
 
 	actualLogs := logBuffer.String()
 
-	assert.Contains(t, actualLogs, fmt.Sprintf(`
-version: dev
-commit: ?
-built at: ?
-using: %s`, runtime.Version()))
+	assert.Contains(t, actualLogs, "\nversion: dev")
+	assert.Regexp(t, `\ncommit: .+`, actualLogs)
+	assert.Regexp(t, `\nbuilt at: .+`, actualLogs)
+	assert.Contains(t, actualLogs, fmt.Sprintf("\nusing: %s", runtime.Version()))
 
 	fmt.Println(actualLogs)
 }


### PR DESCRIPTION
## Summary
- enrich `--version` output by resolving build metadata from `runtime/debug` (`vcs.revision`, `vcs.time`) when ldflags values are unset
- keep GoReleaser ldflags behavior as the primary source when `internal.version`, `internal.commit`, and `internal.date` are provided
- make acceptance test assertions metadata-aware so local VCS-embedded builds are covered

## Validation
- `go generate ./...`
- `go test -short ./...`
- `go vet ./...`
- `golangci-lint run`
- `go build -o terradozer && ./terradozer --version`
  - outputs `commit` and `built at` from runtime build info in local builds
- `go build -ldflags "-X github.com/jckuester/terradozer/internal.version=v0.2.0 -X github.com/jckuester/terradozer/internal.commit=deadbee -X github.com/jckuester/terradozer/internal.date=2026-02-26T22:00:00Z" -o terradozer && ./terradozer --version`
  - confirms ldflags values still take precedence
