### PR TITLE
feat: add GoReleaser release artifact attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  attestations: write
+  id-token: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -38,3 +40,10 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/terradozer_*_*_*.tar.gz
+            dist/terradozer_*_checksums.txt

--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ Supported release targets:
 - `os`: `darwin`, `linux`
 - `arch`: `amd64`, `arm64`
 
+### Verify Release Provenance
+
+Release assets are published with GitHub Artifact Attestations. To verify a downloaded
+asset and checksums file (example: `v0.1.2`):
+
+```bash
+VERSION=v0.1.2
+ASSET="terradozer_${VERSION}_linux_amd64.tar.gz"
+CHECKSUMS="terradozer_${VERSION}_checksums.txt"
+
+gh release download "$VERSION" --repo chenrui333/terradozer --pattern "$ASSET" --pattern "$CHECKSUMS"
+
+gh attestation verify "$ASSET" --repo chenrui333/terradozer
+gh attestation verify "$CHECKSUMS" --repo chenrui333/terradozer
+
+grep " $ASSET$" "$CHECKSUMS" | shasum -a 256 -c -
+```
+
 Here is the recommended way to install a specific version (example: `v0.1.2`):
 
 ```bash


### PR DESCRIPTION
## Summary
- add GitHub artifact attestation permissions to the release workflow
- attest GoReleaser release assets (`.tar.gz` archives and checksums)
- document provenance verification steps in README

## Validation
- reviewed workflow and docs diff locally

Closes #17