### PR TITLE
Publish attestation bundles with release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,21 @@ jobs:
           subject-path: |
             dist/terradozer_*_*_*.tar.gz
             dist/terradozer_*_checksums.txt
+
+      - name: Download attestation bundles
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for artifact in dist/terradozer_*_*_*.tar.gz dist/terradozer_*_checksums.txt; do
+            gh attestation download "$artifact" --repo "${GITHUB_REPOSITORY}"
+          done
+          mkdir -p dist/attestations
+          mv sha*.jsonl dist/attestations/
+
+      - name: Upload attestation bundles to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/attestations/*.jsonl
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Supported release targets:
 
 ### Verify Release Provenance
 
-Release assets are published with GitHub Artifact Attestations. To verify a downloaded
-asset and checksums file (example: `v0.1.2`):
+Release assets are published with GitHub Artifact Attestations, and matching attestation
+bundles (`sha256*.jsonl`) are attached to each release. To verify a downloaded asset and
+checksums file (example: `v0.1.2`):
 
 ```bash
 VERSION=v0.1.2
@@ -67,6 +68,15 @@ gh attestation verify "$ASSET" --repo chenrui333/terradozer
 gh attestation verify "$CHECKSUMS" --repo chenrui333/terradozer
 
 grep " $ASSET$" "$CHECKSUMS" | shasum -a 256 -c -
+
+# Optional: offline verification with the release-attached bundle for this artifact
+gh release download "$VERSION" --repo chenrui333/terradozer --pattern "sha256*.jsonl"
+DIGEST="$(shasum -a 256 "$ASSET" | awk '{print $1}')"
+BUNDLE="sha256-${DIGEST}.jsonl"
+if [ ! -f "$BUNDLE" ]; then
+  BUNDLE="sha256:${DIGEST}.jsonl"
+fi
+gh attestation verify "$ASSET" --repo chenrui333/terradozer --bundle "$BUNDLE"
 ```
 
 Here is the recommended way to install a specific version (example: `v0.1.2`):


### PR DESCRIPTION
## Summary
- keep GitHub-native artifact attestations in the release workflow
- download generated attestation bundles (`sha256*.jsonl`) for each release artifact
- upload those bundles to the tagged GitHub release via `softprops/action-gh-release`
- document release-attached bundle verification in README

## Validation
- reviewed workflow and README diffs locally
- verified `gh attestation download`/`verify` usage against current release assets
