### PR TITLE
fix: guard invalid destroy parallelism

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,13 @@ func mainExitCode() int {
 		return 1
 	}
 
+	if parallel < 1 {
+		fmt.Fprint(os.Stderr, color.RedString("Error: -parallel flag must be greater than 0\n"))
+		printHelp(flags)
+
+		return 1
+	}
+
 	timeoutDuration, err := time.ParseDuration(timeout)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("Error: failed to parse timeout flag: %s\n", err))

--- a/main_test.go
+++ b/main_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -78,14 +80,58 @@ func TestSetAWSProfileToDefault(t *testing.T) {
 }
 
 func TestMainExitCodeRejectsInvalidParallel(t *testing.T) {
-	originalArgs := os.Args
-	t.Cleanup(func() {
-		os.Args = originalArgs
-	})
+	testCases := []struct {
+		name     string
+		parallel string
+	}{
+		{
+			name:     "zero",
+			parallel: "0",
+		},
+		{
+			name:     "negative",
+			parallel: "-1",
+		},
+	}
 
-	os.Args = []string{"terradozer", "-parallel", "0", "terraform.tfstate"}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalArgs := os.Args
+			os.Args = []string{"terradozer", "-parallel", tc.parallel, "terraform.tfstate"}
+			t.Cleanup(func() {
+				os.Args = originalArgs
+			})
 
-	assert.Equal(t, 1, mainExitCode())
+			stderr := captureStderr(t, func() {
+				assert.Equal(t, 1, mainExitCode())
+			})
+
+			assert.Contains(t, stderr, "-parallel flag must be greater than 0")
+		})
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer r.Close()
+
+	os.Stderr = w
+	defer func() {
+		os.Stderr = originalStderr
+	}()
+
+	fn()
+
+	require.NoError(t, w.Close())
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	return string(output)
 }
 
 func TestInitProvidersSkipsUnsupportedProviders(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -77,6 +77,17 @@ func TestSetAWSProfileToDefault(t *testing.T) {
 	}
 }
 
+func TestMainExitCodeRejectsInvalidParallel(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	os.Args = []string{"terradozer", "-parallel", "0", "terraform.tfstate"}
+
+	assert.Equal(t, 1, mainExitCode())
+}
+
 func TestInitProvidersSkipsUnsupportedProviders(t *testing.T) {
 	p, err := initProviders([]string{"google"}, ".terradozer", 10*time.Second)
 	assert.NoError(t, err)

--- a/pkg/resource/destroy.go
+++ b/pkg/resource/destroy.go
@@ -23,6 +23,11 @@ type DestroyableResource interface {
 // the remaining, failed resources will be retried in a next run (until all resources are destroyed or
 // some destroys have permanently failed).
 func DestroyResources(resources []DestroyableResource, parallel int) int {
+	if parallel < 1 {
+		log.WithField("parallel", parallel).Warn(internal.Pad("invalid parallelism; using one worker"))
+		parallel = 1
+	}
+
 	numOfResourcesToDelete := len(resources)
 	numOfDeletedResources := 0
 

--- a/pkg/resource/destroy_test.go
+++ b/pkg/resource/destroy_test.go
@@ -42,6 +42,22 @@ func TestDestroyResources(t *testing.T) {
 			parallel:              1,
 		},
 		{
+			name: "single resource deleted when parallel is zero",
+			failedDeletions: map[string]int{
+				"aws_vpc": 0,
+			},
+			expectedDeletionCount: 1,
+			parallel:              0,
+		},
+		{
+			name: "single resource deleted when parallel is negative",
+			failedDeletions: map[string]int{
+				"aws_vpc": 0,
+			},
+			expectedDeletionCount: 1,
+			parallel:              -1,
+		},
+		{
 			name: "single resource failed in first run",
 			failedDeletions: map[string]int{
 				"aws_vpc": 1,


### PR DESCRIPTION
## Summary
- reject `--parallel < 1` before reading state or initializing providers
- keep `DestroyResources` defensive by falling back to one worker for invalid direct calls
- add tests for CLI validation and zero/negative helper parallelism

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on invalid `-parallel` values and default destroy parallelism to one worker when called incorrectly.

- **Bug Fixes**
  - CLI rejects `-parallel < 1` before reading state or initializing providers, prints help and a clear error, and exits.
  - `pkg/resource` `DestroyResources` guards `parallel < 1`, logs a warning, and uses one worker.
  - Tests cover CLI validation, zero/negative parallel cases, and assert the stderr error message.

<sup>Written for commit 1c3d4d306d4b64bfe977400d67e8a20b65be3afb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate the `-parallel` flag: values must be greater than 0. Invalid inputs show an error message and exit with status code 1.
  * Resource destruction now enforces a minimum parallel worker count of 1 to prevent invalid configurations.

* **Tests**
  * Added test cases for invalid `-parallel` values, including zero and negative inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->