### PR TITLE
feat: add AWS destroy priority ordering

### DIFF
--- a/pkg/resource/destroy.go
+++ b/pkg/resource/destroy.go
@@ -9,7 +9,10 @@ import (
 	"github.com/jckuester/terradozer/internal"
 )
 
-const fieldType = "type"
+const (
+	fieldType              = "type"
+	defaultDestroyPriority = 0
+)
 
 // DestroyableResource implementations can destroy a Terraform resource.
 type DestroyableResource interface {
@@ -110,12 +113,13 @@ func groupDestroyableResourcesByPriority(resources []DestroyableResource) []dest
 	resourcesToDelete := append([]DestroyableResource(nil), resources...)
 
 	sort.SliceStable(resourcesToDelete, func(i, j int) bool {
-		return priorityByType[resourcesToDelete[i].Type()] < priorityByType[resourcesToDelete[j].Type()]
+		return destroyPriority(resourcesToDelete[i].Type(), priorityByType) <
+			destroyPriority(resourcesToDelete[j].Type(), priorityByType)
 	})
 
 	buckets := []destroyPriorityBucket{}
 	for _, r := range resourcesToDelete {
-		priority := priorityByType[r.Type()]
+		priority := destroyPriority(r.Type(), priorityByType)
 		lastBucketIndex := len(buckets) - 1
 		if len(buckets) == 0 || buckets[lastBucketIndex].priority != priority {
 			buckets = append(buckets, destroyPriorityBucket{priority: priority})
@@ -126,6 +130,16 @@ func groupDestroyableResourcesByPriority(resources []DestroyableResource) []dest
 	}
 
 	return buckets
+}
+
+func destroyPriority(resourceType string, priorityByType map[string]int) int {
+	priority, ok := priorityByType[resourceType]
+	if !ok {
+		// Unknown resource types intentionally run first to avoid delaying known dependency chains.
+		return defaultDestroyPriority
+	}
+
+	return priority
 }
 
 func destroyPriorityByType() map[string]int {

--- a/pkg/resource/destroy.go
+++ b/pkg/resource/destroy.go
@@ -29,42 +29,16 @@ func DestroyResources(resources []DestroyableResource, parallel int) int {
 		parallel = 1
 	}
 
-	numOfResourcesToDelete := len(resources)
 	numOfDeletedResources := 0
 
 	var retryableResourceErrors []RetryDestroyError
 
-	resourcesToDelete := append([]DestroyableResource(nil), resources...)
-	sortDestroyableResources(resourcesToDelete)
+	resourceBuckets := groupDestroyableResourcesByPriority(resources)
 
-	jobQueue := make(chan DestroyableResource, numOfResourcesToDelete)
-
-	workerResults := make(chan workerResult, numOfResourcesToDelete)
-
-	for i := 1; i <= parallel; i++ {
-		go workerDestroy(jobQueue, workerResults)
-	}
-
-	log.Debug("start distributing resources to workers for this run")
-
-	for _, r := range resourcesToDelete {
-		jobQueue <- r
-	}
-
-	close(jobQueue)
-
-	for i := 1; i <= numOfResourcesToDelete; i++ {
-		result := <-workerResults
-
-		if result.resourceHasBeenDeleted {
-			numOfDeletedResources++
-
-			continue
-		}
-
-		if result.Err != nil {
-			retryableResourceErrors = append(retryableResourceErrors, *result.Err)
-		}
+	for _, bucket := range resourceBuckets {
+		deletedResources, retryableErrors := destroyResourceBucket(bucket.resources, parallel)
+		numOfDeletedResources += deletedResources
+		retryableResourceErrors = append(retryableResourceErrors, retryableErrors...)
 	}
 
 	if len(retryableResourceErrors) > 0 && numOfDeletedResources > 0 {
@@ -88,12 +62,70 @@ func DestroyResources(resources []DestroyableResource, parallel int) int {
 	return numOfDeletedResources
 }
 
-func sortDestroyableResources(resources []DestroyableResource) {
-	priorityByType := destroyPriorityByType()
+func destroyResourceBucket(resources []DestroyableResource, parallel int) (int, []RetryDestroyError) {
+	numOfResourcesToDelete := len(resources)
+	numOfDeletedResources := 0
+	retryableResourceErrors := []RetryDestroyError{}
 
-	sort.SliceStable(resources, func(i, j int) bool {
-		return priorityByType[resources[i].Type()] < priorityByType[resources[j].Type()]
+	jobQueue := make(chan DestroyableResource, numOfResourcesToDelete)
+
+	workerResults := make(chan workerResult, numOfResourcesToDelete)
+
+	for i := 1; i <= parallel; i++ {
+		go workerDestroy(jobQueue, workerResults)
+	}
+
+	log.Debug("start distributing resources to workers for this run")
+
+	for _, r := range resources {
+		jobQueue <- r
+	}
+
+	close(jobQueue)
+
+	for i := 1; i <= numOfResourcesToDelete; i++ {
+		result := <-workerResults
+
+		if result.resourceHasBeenDeleted {
+			numOfDeletedResources++
+
+			continue
+		}
+
+		if result.Err != nil {
+			retryableResourceErrors = append(retryableResourceErrors, *result.Err)
+		}
+	}
+
+	return numOfDeletedResources, retryableResourceErrors
+}
+
+type destroyPriorityBucket struct {
+	priority  int
+	resources []DestroyableResource
+}
+
+func groupDestroyableResourcesByPriority(resources []DestroyableResource) []destroyPriorityBucket {
+	priorityByType := destroyPriorityByType()
+	resourcesToDelete := append([]DestroyableResource(nil), resources...)
+
+	sort.SliceStable(resourcesToDelete, func(i, j int) bool {
+		return priorityByType[resourcesToDelete[i].Type()] < priorityByType[resourcesToDelete[j].Type()]
 	})
+
+	buckets := []destroyPriorityBucket{}
+	for _, r := range resourcesToDelete {
+		priority := priorityByType[r.Type()]
+		lastBucketIndex := len(buckets) - 1
+		if len(buckets) == 0 || buckets[lastBucketIndex].priority != priority {
+			buckets = append(buckets, destroyPriorityBucket{priority: priority})
+			lastBucketIndex = len(buckets) - 1
+		}
+
+		buckets[lastBucketIndex].resources = append(buckets[lastBucketIndex].resources, r)
+	}
+
+	return buckets
 }
 
 func destroyPriorityByType() map[string]int {

--- a/pkg/resource/destroy.go
+++ b/pkg/resource/destroy.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/apex/log"
 	"github.com/jckuester/terradozer/internal"
@@ -33,6 +34,9 @@ func DestroyResources(resources []DestroyableResource, parallel int) int {
 
 	var retryableResourceErrors []RetryDestroyError
 
+	resourcesToDelete := append([]DestroyableResource(nil), resources...)
+	sortDestroyableResources(resourcesToDelete)
+
 	jobQueue := make(chan DestroyableResource, numOfResourcesToDelete)
 
 	workerResults := make(chan workerResult, numOfResourcesToDelete)
@@ -43,7 +47,7 @@ func DestroyResources(resources []DestroyableResource, parallel int) int {
 
 	log.Debug("start distributing resources to workers for this run")
 
-	for _, r := range resources {
+	for _, r := range resourcesToDelete {
 		jobQueue <- r
 	}
 
@@ -82,6 +86,59 @@ func DestroyResources(resources []DestroyableResource, parallel int) int {
 	}
 
 	return numOfDeletedResources
+}
+
+func sortDestroyableResources(resources []DestroyableResource) {
+	priorityByType := destroyPriorityByType()
+
+	sort.SliceStable(resources, func(i, j int) bool {
+		return priorityByType[resources[i].Type()] < priorityByType[resources[j].Type()]
+	})
+}
+
+func destroyPriorityByType() map[string]int {
+	return map[string]int{
+		// EKS chain.
+		"aws_eks_addon":                     10,
+		"aws_eks_node_group":                20,
+		"aws_eks_access_entry":              25,
+		"aws_eks_access_policy_association": 25,
+		"aws_eks_cluster":                   30,
+
+		// Load balancer chain.
+		"aws_lb_listener":      10,
+		"aws_lb_listener_rule": 10,
+		"aws_lb_target_group":  15,
+		"aws_lb":               20,
+		"aws_alb_listener":     10,
+		"aws_alb_target_group": 15,
+		"aws_alb":              20,
+
+		// Network chain.
+		"aws_route_table_association": 10,
+		"aws_route":                   15,
+		"aws_route_table":             20,
+		"aws_nat_gateway":             25,
+		"aws_eip":                     30,
+		"aws_security_group_rule":     35,
+		"aws_network_interface":       38,
+		"aws_subnet":                  40,
+		"aws_security_group":          45,
+		"aws_internet_gateway":        48,
+		"aws_vpc":                     50,
+
+		// IAM chain.
+		"aws_iam_role_policy_attachment": 10,
+		"aws_iam_role_policy":            10,
+		"aws_iam_policy":                 20,
+		"aws_iam_instance_profile":       25,
+		"aws_iam_role":                   30,
+
+		// S3 chain.
+		"aws_s3_bucket_policy":     10,
+		"aws_s3_bucket_versioning": 10,
+		"aws_s3_bucket":            20,
+	}
 }
 
 type workerResult struct {

--- a/pkg/resource/destroy_test.go
+++ b/pkg/resource/destroy_test.go
@@ -164,6 +164,53 @@ func TestDestroyResources_OrdersAWSResourcesByPriority(t *testing.T) {
 	}, actualOrder)
 }
 
+func TestDestroyResources_WaitsForPriorityBucketBeforeNextBucket(t *testing.T) {
+	lowPriorityStarted := make(chan struct{})
+	releaseLowPriority := make(chan struct{})
+	highPriorityStarted := make(chan struct{})
+	done := make(chan int, 1)
+
+	resources := []resource.DestroyableResource{
+		&blockingDestroyableResource{resourceType: "aws_vpc", started: highPriorityStarted},
+		&blockingDestroyableResource{
+			resourceType: "aws_eks_addon",
+			started:      lowPriorityStarted,
+			release:      releaseLowPriority,
+		},
+	}
+
+	go func() {
+		done <- resource.DestroyResources(resources, 2)
+	}()
+
+	select {
+	case <-lowPriorityStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for low-priority-number resource to start")
+	}
+
+	select {
+	case <-highPriorityStarted:
+		t.Fatal("higher-priority-number resource started before earlier priority bucket finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseLowPriority)
+
+	select {
+	case <-highPriorityStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for higher-priority-number resource to start")
+	}
+
+	select {
+	case actualDeletionCount := <-done:
+		assert.Equal(t, len(resources), actualDeletionCount)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for destroy to finish")
+	}
+}
+
 type recordingDestroyableResource struct {
 	resourceType string
 	order        *[]string
@@ -180,6 +227,32 @@ func (r *recordingDestroyableResource) Type() string {
 }
 
 func (r *recordingDestroyableResource) ID() string {
+	return r.resourceType
+}
+
+type blockingDestroyableResource struct {
+	resourceType string
+	started      chan<- struct{}
+	release      <-chan struct{}
+}
+
+func (r *blockingDestroyableResource) Destroy() error {
+	if r.started != nil {
+		close(r.started)
+	}
+
+	if r.release != nil {
+		<-r.release
+	}
+
+	return nil
+}
+
+func (r *blockingDestroyableResource) Type() string {
+	return r.resourceType
+}
+
+func (r *blockingDestroyableResource) ID() string {
 	return r.resourceType
 }
 

--- a/pkg/resource/destroy_test.go
+++ b/pkg/resource/destroy_test.go
@@ -3,6 +3,7 @@ package resource_test
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -232,14 +233,17 @@ func (r *recordingDestroyableResource) ID() string {
 
 type blockingDestroyableResource struct {
 	resourceType string
+	closeOnce    sync.Once
 	started      chan<- struct{}
 	release      <-chan struct{}
 }
 
 func (r *blockingDestroyableResource) Destroy() error {
-	if r.started != nil {
-		close(r.started)
-	}
+	r.closeOnce.Do(func() {
+		if r.started != nil {
+			close(r.started)
+		}
+	})
 
 	if r.release != nil {
 		<-r.release

--- a/pkg/resource/destroy_test.go
+++ b/pkg/resource/destroy_test.go
@@ -140,6 +140,49 @@ func TestDestroyResources_DestroyError(t *testing.T) {
 	assert.Equal(t, actualDeletionCount, 0)
 }
 
+func TestDestroyResources_OrdersAWSResourcesByPriority(t *testing.T) {
+	var actualOrder []string
+	resources := []resource.DestroyableResource{
+		&recordingDestroyableResource{resourceType: "aws_vpc", order: &actualOrder},
+		&recordingDestroyableResource{resourceType: "aws_eks_cluster", order: &actualOrder},
+		&recordingDestroyableResource{resourceType: "aws_eks_addon", order: &actualOrder},
+		&recordingDestroyableResource{resourceType: "aws_subnet", order: &actualOrder},
+		&recordingDestroyableResource{resourceType: "aws_security_group_rule", order: &actualOrder},
+		&recordingDestroyableResource{resourceType: "custom_resource", order: &actualOrder},
+	}
+
+	actualDeletionCount := resource.DestroyResources(resources, 1)
+
+	assert.Equal(t, len(resources), actualDeletionCount)
+	assert.Equal(t, []string{
+		"custom_resource",
+		"aws_eks_addon",
+		"aws_eks_cluster",
+		"aws_security_group_rule",
+		"aws_subnet",
+		"aws_vpc",
+	}, actualOrder)
+}
+
+type recordingDestroyableResource struct {
+	resourceType string
+	order        *[]string
+}
+
+func (r *recordingDestroyableResource) Destroy() error {
+	*r.order = append(*r.order, r.resourceType)
+
+	return nil
+}
+
+func (r *recordingDestroyableResource) Type() string {
+	return r.resourceType
+}
+
+func (r *recordingDestroyableResource) ID() string {
+	return r.resourceType
+}
+
 func TestResource_Destroy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test.")

--- a/test/helper.go
+++ b/test/helper.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/aws/awserr"     //nolint:staticcheck // Acceptance helpers still use AWS SDK v1.
+	"github.com/aws/aws-sdk-go/service/ecs"    //nolint:staticcheck // Acceptance helpers still use AWS SDK v1.
+	"github.com/aws/aws-sdk-go/service/iam"    //nolint:staticcheck // Acceptance helpers still use AWS SDK v1.
+	"github.com/aws/aws-sdk-go/service/lambda" //nolint:staticcheck // Acceptance helpers still use AWS SDK v1.
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/jckuester/awstools-lib/test"


### PR DESCRIPTION
## Summary
- sort destroy jobs with a stable AWS resource priority map before worker dispatch
- enforce priority tiers by running one priority bucket at a time while preserving parallelism within each bucket
- add unit coverage for serial ordering and default-parallel bucket gating
- suppress existing AWS SDK v1 deprecation warnings in acceptance-test helpers so golangci-lint v2 stays actionable

## References
Closes #33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource destruction now runs in deterministic priority buckets so higher-priority items are deleted before lower-priority ones and buckets complete before the next starts.
  * Retry handling is scoped per priority bucket, improving retry behavior and error aggregation during teardown.

* **Tests**
  * Added tests validating priority ordering and that a priority bucket fully finishes before the next begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->