### PR TITLE
feat: support S3 state paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Happy (terra)dozing!
   your approval
 * Using the `-force` flag (dangerous!), terradozer can run in an automated fashion without human interaction and approval,
   for example, as part of your CI pipeline
-* **Planned** ([#48](https://github.com/chenrui333/terradozer/issues/48)):
-  Allow terradozer pointing directly to a state file stored in S3, i.e., `terradozer s3://path/to/terraform.tfstate`
+* Read Terraform state from a local file or S3 path, i.e., `terradozer s3://bucket/path/to/terraform.tfstate`
 * **Planned** ([#49](https://github.com/chenrui333/terradozer/issues/49)):
   A `-recursive` flag to delete resources of all states found under a given directory, i.e.,
   `terradozer -recursive s3://bucket-with-states/`. This is especially helpful if
@@ -90,10 +89,9 @@ curl -sSfL https://raw.githubusercontent.com/chenrui333/terradozer/main/install.
 
 To delete all resources in a Terraform state file:
 
-    terradozer [flags] <path/to/terraform.tfstate>
+    terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
 
-To see all options, run `terradozer --help`. Provide credentials for the AWS account you want to destroy resources in
-via the usual [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), e.g.,
+To see all options, run `terradozer --help`. Provide credentials for the AWS account you want to read state from and destroy resources in via the usual [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), e.g.,
 `AWS_PROFILE=<myaccount>` and either `AWS_REGION=<myregion>` or `AWS_DEFAULT_REGION=<myregion>`.
 If `AWS_PROFILE` is unset, terradozer uses the `default` profile.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/apex/log v1.9.0
 	github.com/aws/aws-sdk-go v1.55.8
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.47.2
 	github.com/aws/aws-sdk-go-v2/service/acm v1.38.3
@@ -159,7 +160,6 @@ require (
 	github.com/apparentlymart/go-textseg v1.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v12 v12.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect

--- a/internal/awstools/terraform/provider_pool.go
+++ b/internal/awstools/terraform/provider_pool.go
@@ -51,6 +51,9 @@ func (p *providerPoolThreadSafe) closeAll(cause error) error {
 
 func providerConfigForClientKey(key aws.ClientKey) cty.Value {
 	config := provider.AWSProviderConfig().AsValueMap()
+	config["access_key"] = cty.UnknownVal(cty.DynamicPseudoType)
+	config["secret_key"] = cty.UnknownVal(cty.DynamicPseudoType)
+	config["token"] = cty.UnknownVal(cty.DynamicPseudoType)
 	config[logFieldProfile] = cty.StringVal(key.Profile)
 	config[logFieldRegion] = cty.StringVal(key.Region)
 

--- a/internal/awstools/terraform/provider_pool_test.go
+++ b/internal/awstools/terraform/provider_pool_test.go
@@ -1,0 +1,28 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terradozer/internal/awstools/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestProviderConfigForClientKeyDoesNotInheritStaticCredentials(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret-key")
+	t.Setenv("AWS_SESSION_TOKEN", "env-session-token")
+	t.Setenv("AWS_PROFILE", "env-profile")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	config := providerConfigForClientKey(aws.ClientKey{
+		Profile: "target-profile",
+		Region:  "us-west-2",
+	}).AsValueMap()
+
+	assert.True(t, config[logFieldProfile].RawEquals(cty.StringVal("target-profile")))
+	assert.True(t, config[logFieldRegion].RawEquals(cty.StringVal("us-west-2")))
+	assert.False(t, config["access_key"].IsWhollyKnown())
+	assert.False(t, config["secret_key"].IsWhollyKnown())
+	assert.False(t, config["token"].IsWhollyKnown())
+}

--- a/main.go
+++ b/main.go
@@ -103,9 +103,7 @@ func mainExitCode() int {
 
 	setAWSRegionFromDefault()
 
-	stateReadCtx, cancelStateRead := context.WithTimeout(context.Background(), timeoutDuration)
-	tfstate, err := state.NewWithContext(stateReadCtx, pathToState)
-	cancelStateRead()
+	tfstate, err := state.New(pathToState)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("Error:️ failed to read Terraform state file: %s\n", err))
 

--- a/main.go
+++ b/main.go
@@ -103,7 +103,9 @@ func mainExitCode() int {
 
 	setAWSRegionFromDefault()
 
-	tfstate, err := state.New(pathToState)
+	stateReadCtx, cancelStateRead := context.WithTimeout(context.Background(), timeoutDuration)
+	tfstate, err := state.NewWithContext(stateReadCtx, pathToState)
+	cancelStateRead()
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("Error:️ failed to read Terraform state file: %s\n", err))
 

--- a/main.go
+++ b/main.go
@@ -16,12 +16,12 @@ import (
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
-	"github.com/fatih/color"
 	"github.com/chenrui333/terradozer/internal"
 	"github.com/chenrui333/terradozer/internal/awstools/terraform"
 	"github.com/chenrui333/terradozer/internal/awstools/terraform/provider"
 	"github.com/chenrui333/terradozer/pkg/resource"
 	"github.com/chenrui333/terradozer/pkg/state"
+	"github.com/fatih/color"
 )
 
 func main() {
@@ -101,6 +101,9 @@ func mainExitCode() int {
 
 	pathToState := args[0]
 
+	setAWSRegionFromDefault()
+	setAWSProfileToDefault()
+
 	tfstate, err := state.New(pathToState)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("Error:️ failed to read Terraform state file: %s\n", err))
@@ -109,10 +112,7 @@ func mainExitCode() int {
 	}
 
 	internal.LogTitle("reading state")
-	log.WithField("file", pathToState).Info(internal.Pad("using state"))
-
-	setAWSRegionFromDefault()
-	setAWSProfileToDefault()
+	log.WithField("source", pathToState).Info(internal.Pad("using state"))
 
 	providers, err := initProviders(tfstate.ProviderNames(), "~/.terradozer", timeoutDuration)
 	if err != nil {
@@ -270,7 +270,7 @@ const help = `
 Terraform destroy using only the state - no *.tf files needed.
 
 USAGE:
-  $ terradozer [flags] <path/to/terraform.tfstate>
+  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
 
 FLAGS:
 `

--- a/main.go
+++ b/main.go
@@ -102,7 +102,6 @@ func mainExitCode() int {
 	pathToState := args[0]
 
 	setAWSRegionFromDefault()
-	setAWSProfileToDefault()
 
 	tfstate, err := state.New(pathToState)
 	if err != nil {
@@ -113,6 +112,8 @@ func mainExitCode() int {
 
 	internal.LogTitle("reading state")
 	log.WithField("source", pathToState).Info(internal.Pad("using state"))
+
+	setAWSProfileToDefault()
 
 	providers, err := initProviders(tfstate.ProviderNames(), "~/.terradozer", timeoutDuration)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -112,6 +112,26 @@ func TestMainExitCodeRejectsInvalidParallel(t *testing.T) {
 	}
 }
 
+func TestMainExitCodeDoesNotDefaultProfileBeforeStateRead(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret-key")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_PROFILE", "")
+
+	originalArgs := os.Args
+	os.Args = []string{"terradozer", "s3://state-bucket/path/to/terraform.tfstate?versionId=123"}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	stderr := captureStderr(t, func() {
+		assert.Equal(t, 1, mainExitCode())
+	})
+
+	assert.Contains(t, stderr, "must not include query or fragment components")
+	assert.Empty(t, os.Getenv("AWS_PROFILE"))
+}
+
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/pkg/state/s3_test.go
+++ b/pkg/state/s3_test.go
@@ -40,6 +40,18 @@ func TestParseS3StateSource(t *testing.T) {
 			expectedS3:  true,
 			expectedErr: "must include a key",
 		},
+		{
+			name:        "query component",
+			source:      "s3://state-bucket/path/to/terraform.tfstate?versionId=123",
+			expectedS3:  true,
+			expectedErr: "must not include query or fragment",
+		},
+		{
+			name:        "fragment component",
+			source:      "s3://state-bucket/path/to/terraform.tfstate#version",
+			expectedS3:  true,
+			expectedErr: "must not include query or fragment",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/state/s3_test.go
+++ b/pkg/state/s3_test.go
@@ -77,6 +77,16 @@ func TestParseS3StateSource(t *testing.T) {
 	}
 }
 
+func TestParseS3StateSourceRejectsMalformedCredentialedURIWithoutLeakingCredentials(t *testing.T) {
+	_, isS3, err := parseS3StateSource("s3://access:secret@state-bucket/path%zz")
+
+	assert.True(t, isS3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not include embedded credentials")
+	assert.NotContains(t, err.Error(), "access")
+	assert.NotContains(t, err.Error(), "secret")
+}
+
 func TestNewReadsS3StateSource(t *testing.T) {
 	stateData, err := os.ReadFile("../../test/test-fixtures/tfstates/version4.tfstate")
 	require.NoError(t, err)

--- a/pkg/state/s3_test.go
+++ b/pkg/state/s3_test.go
@@ -41,6 +41,12 @@ func TestParseS3StateSource(t *testing.T) {
 			expectedErr: "must include a key",
 		},
 		{
+			name:        "embedded credentials",
+			source:      "s3://access:secret@state-bucket/path/to/terraform.tfstate",
+			expectedS3:  true,
+			expectedErr: "must not include embedded credentials",
+		},
+		{
 			name:        "query component",
 			source:      "s3://state-bucket/path/to/terraform.tfstate?versionId=123",
 			expectedS3:  true,

--- a/pkg/state/s3_test.go
+++ b/pkg/state/s3_test.go
@@ -81,7 +81,7 @@ func TestNewReadsS3StateSource(t *testing.T) {
 	stateData, err := os.ReadFile("../../test/test-fixtures/tfstates/version4.tfstate")
 	require.NoError(t, err)
 
-	actualState, err := newWithS3ObjectReader("s3://state-bucket/path/to/terraform.tfstate",
+	actualState, err := newWithS3ObjectReader(context.Background(), "s3://state-bucket/path/to/terraform.tfstate",
 		func(ctx context.Context, bucket, key string) ([]byte, error) {
 			assert.Equal(t, "state-bucket", bucket)
 			assert.Equal(t, "path/to/terraform.tfstate", key)
@@ -94,7 +94,7 @@ func TestNewReadsS3StateSource(t *testing.T) {
 }
 
 func TestNewReturnsS3ReadError(t *testing.T) {
-	actualState, err := newWithS3ObjectReader("s3://state-bucket/path/to/terraform.tfstate",
+	actualState, err := newWithS3ObjectReader(context.Background(), "s3://state-bucket/path/to/terraform.tfstate",
 		func(ctx context.Context, bucket, key string) ([]byte, error) {
 			return nil, errors.New("access denied")
 		})
@@ -102,4 +102,17 @@ func TestNewReturnsS3ReadError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, actualState)
 	assert.Contains(t, err.Error(), "access denied")
+}
+
+func TestNewWithContextPassesContextToS3Reader(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	actualState, err := newWithS3ObjectReader(ctx, "s3://state-bucket/path/to/terraform.tfstate",
+		func(ctx context.Context, bucket, key string) ([]byte, error) {
+			return nil, ctx.Err()
+		})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, actualState)
 }

--- a/pkg/state/s3_test.go
+++ b/pkg/state/s3_test.go
@@ -1,0 +1,87 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseS3StateSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      string
+		expected    s3StateSource
+		expectedS3  bool
+		expectedErr string
+	}{
+		{
+			name:   "local path",
+			source: "terraform.tfstate",
+		},
+		{
+			name:       "S3 path",
+			source:     "s3://state-bucket/path/to/terraform.tfstate",
+			expected:   s3StateSource{bucket: "state-bucket", key: "path/to/terraform.tfstate"},
+			expectedS3: true,
+		},
+		{
+			name:        "missing bucket",
+			source:      "s3:///path/to/terraform.tfstate",
+			expectedS3:  true,
+			expectedErr: "must include a bucket",
+		},
+		{
+			name:        "missing key",
+			source:      "s3://state-bucket",
+			expectedS3:  true,
+			expectedErr: "must include a key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, isS3, err := parseS3StateSource(tc.source)
+
+			assert.Equal(t, tc.expectedS3, isS3)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestNewReadsS3StateSource(t *testing.T) {
+	stateData, err := os.ReadFile("../../test/test-fixtures/tfstates/version4.tfstate")
+	require.NoError(t, err)
+
+	actualState, err := newWithS3ObjectReader("s3://state-bucket/path/to/terraform.tfstate",
+		func(ctx context.Context, bucket, key string) ([]byte, error) {
+			assert.Equal(t, "state-bucket", bucket)
+			assert.Equal(t, "path/to/terraform.tfstate", key)
+
+			return stateData, nil
+		})
+	require.NoError(t, err)
+	require.NotNil(t, actualState)
+	assert.Equal(t, []string{"aws"}, actualState.ProviderNames())
+}
+
+func TestNewReturnsS3ReadError(t *testing.T) {
+	actualState, err := newWithS3ObjectReader("s3://state-bucket/path/to/terraform.tfstate",
+		func(ctx context.Context, bucket, key string) ([]byte, error) {
+			return nil, errors.New("access denied")
+		})
+
+	require.Error(t, err)
+	assert.Nil(t, actualState)
+	assert.Contains(t, err.Error(), "access denied")
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3,21 +3,28 @@ package state
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/url"
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/apex/log"
-	"github.com/hashicorp/terraform/addrs"
-	"github.com/hashicorp/terraform/states"
-	"github.com/hashicorp/terraform/states/statefile"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/chenrui333/terradozer/internal"
 	"github.com/chenrui333/terradozer/internal/awstools/terraform"
 	"github.com/chenrui333/terradozer/internal/awstools/terraform/provider"
 	"github.com/chenrui333/terradozer/pkg/resource"
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/states"
+	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -30,9 +37,15 @@ type State struct {
 	state *states.State
 }
 
-// New creates a state from a given path to a Terraform state file.
-func New(path string) (*State, error) {
-	stateFile, err := getStateFromPath(path)
+type s3ObjectReader func(ctx context.Context, bucket, key string) ([]byte, error)
+
+// New creates a state from a given local path or S3 URI to a Terraform state file.
+func New(source string) (*State, error) {
+	return newWithS3ObjectReader(source, readS3ObjectFromAWS)
+}
+
+func newWithS3ObjectReader(source string, reader s3ObjectReader) (*State, error) {
+	stateFile, err := getStateFromSource(source, reader)
 	if err != nil {
 		return nil, err
 	}
@@ -41,15 +54,15 @@ func New(path string) (*State, error) {
 }
 
 // copied from github.com/hashicorp/terraform/command/show.go
-func getStateFromPath(path string) (*statefile.File, error) {
-	stateData, err := os.ReadFile(path)
+func getStateFromSource(source string, reader s3ObjectReader) (*statefile.File, error) {
+	stateData, err := readStateData(source, reader)
 	if err != nil {
 		return nil, err
 	}
 
 	stateFile, err := readStateFile(stateData)
 	if err != nil {
-		return nil, fmt.Errorf("failed reading %s as a statefile: %s", path, err)
+		return nil, fmt.Errorf("failed reading %s as a statefile: %s", source, err)
 	}
 
 	if len(stateFile.State.ProviderAddrs()) > 0 || !stateJSONHasResources(stateData) {
@@ -63,12 +76,84 @@ func getStateFromPath(path string) (*statefile.File, error) {
 
 	normalizedStateFile, normalizeErr := readStateFile(normalizedStateData)
 	if normalizeErr == nil {
-		log.WithField("file", path).Debug(internal.Pad("normalized Terraform 1.x provider references"))
+		log.WithField("source", source).Debug(internal.Pad("normalized Terraform 1.x provider references"))
 
 		return normalizedStateFile, nil
 	}
 
 	return stateFile, nil
+}
+
+type s3StateSource struct {
+	bucket string
+	key    string
+}
+
+func readStateData(source string, reader s3ObjectReader) ([]byte, error) {
+	s3Source, ok, err := parseS3StateSource(source)
+	if err != nil {
+		return nil, err
+	}
+
+	if ok {
+		return reader(context.Background(), s3Source.bucket, s3Source.key)
+	}
+
+	return os.ReadFile(source)
+}
+
+func parseS3StateSource(source string) (s3StateSource, bool, error) {
+	if !strings.HasPrefix(strings.ToLower(source), "s3://") {
+		return s3StateSource{}, false, nil
+	}
+
+	parsed, err := url.Parse(source)
+	if err != nil {
+		return s3StateSource{}, true, fmt.Errorf("failed to parse S3 state path %q: %w", source, err)
+	}
+
+	if parsed.Host == "" {
+		return s3StateSource{}, true, fmt.Errorf("S3 state path %q must include a bucket", source)
+	}
+
+	key := strings.TrimPrefix(parsed.Path, "/")
+	if key == "" {
+		return s3StateSource{}, true, fmt.Errorf("S3 state path %q must include a key", source)
+	}
+
+	return s3StateSource{bucket: parsed.Host, key: key}, true, nil
+}
+
+func readS3ObjectFromAWS(ctx context.Context, bucket, key string) ([]byte, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	client := s3.NewFromConfig(cfg)
+	object, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get s3://%s/%s: %w", bucket, key, err)
+	}
+
+	if object.Body == nil {
+		return nil, fmt.Errorf("failed to get s3://%s/%s: response body is nil", bucket, key)
+	}
+
+	stateData, err := io.ReadAll(object.Body)
+	closeErr := object.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read s3://%s/%s: %w", bucket, key, err)
+	}
+
+	if closeErr != nil {
+		return nil, fmt.Errorf("failed to close s3://%s/%s response body: %w", bucket, key, closeErr)
+	}
+
+	return stateData, nil
 }
 
 func readStateFile(stateData []byte) (*statefile.File, error) {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -118,6 +118,10 @@ func parseS3StateSource(source string) (s3StateSource, bool, error) {
 		return s3StateSource{}, false, nil
 	}
 
+	if s3SourceHasEmbeddedCredentials(source) {
+		return s3StateSource{}, true, errors.New("S3 state path must not include embedded credentials")
+	}
+
 	parsed, err := url.Parse(source)
 	if err != nil {
 		return s3StateSource{}, true, fmt.Errorf("failed to parse S3 state path: %w", err)
@@ -141,6 +145,16 @@ func parseS3StateSource(source string) (s3StateSource, bool, error) {
 	}
 
 	return s3StateSource{bucket: parsed.Host, key: key}, true, nil
+}
+
+func s3SourceHasEmbeddedCredentials(source string) bool {
+	remainder := source[len("s3://"):]
+	authorityEnd := strings.IndexAny(remainder, "/?#")
+	if authorityEnd == -1 {
+		authorityEnd = len(remainder)
+	}
+
+	return strings.Contains(remainder[:authorityEnd], "@")
 }
 
 func readS3ObjectFromAWS(ctx context.Context, bucket, key string) ([]byte, error) {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -116,6 +116,10 @@ func parseS3StateSource(source string) (s3StateSource, bool, error) {
 		return s3StateSource{}, true, fmt.Errorf("S3 state path %q must include a bucket", source)
 	}
 
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return s3StateSource{}, true, fmt.Errorf("S3 state path %q must not include query or fragment components", source)
+	}
+
 	key := strings.TrimPrefix(parsed.Path, "/")
 	if key == "" {
 		return s3StateSource{}, true, fmt.Errorf("S3 state path %q must include a key", source)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -109,7 +109,11 @@ func parseS3StateSource(source string) (s3StateSource, bool, error) {
 
 	parsed, err := url.Parse(source)
 	if err != nil {
-		return s3StateSource{}, true, fmt.Errorf("failed to parse S3 state path %q: %w", source, err)
+		return s3StateSource{}, true, fmt.Errorf("failed to parse S3 state path: %w", err)
+	}
+
+	if parsed.User != nil {
+		return s3StateSource{}, true, errors.New("S3 state path must not include embedded credentials")
 	}
 
 	if parsed.Host == "" {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -39,13 +40,23 @@ type State struct {
 
 type s3ObjectReader func(ctx context.Context, bucket, key string) ([]byte, error)
 
+const defaultS3StateReadTimeout = 30 * time.Second
+
 // New creates a state from a given local path or S3 URI to a Terraform state file.
 func New(source string) (*State, error) {
-	return newWithS3ObjectReader(source, readS3ObjectFromAWS)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultS3StateReadTimeout)
+	defer cancel()
+
+	return NewWithContext(ctx, source)
 }
 
-func newWithS3ObjectReader(source string, reader s3ObjectReader) (*State, error) {
-	stateFile, err := getStateFromSource(source, reader)
+// NewWithContext creates a state using the provided context for remote state reads.
+func NewWithContext(ctx context.Context, source string) (*State, error) {
+	return newWithS3ObjectReader(ctx, source, readS3ObjectFromAWS)
+}
+
+func newWithS3ObjectReader(ctx context.Context, source string, reader s3ObjectReader) (*State, error) {
+	stateFile, err := getStateFromSource(ctx, source, reader)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +65,8 @@ func newWithS3ObjectReader(source string, reader s3ObjectReader) (*State, error)
 }
 
 // copied from github.com/hashicorp/terraform/command/show.go
-func getStateFromSource(source string, reader s3ObjectReader) (*statefile.File, error) {
-	stateData, err := readStateData(source, reader)
+func getStateFromSource(ctx context.Context, source string, reader s3ObjectReader) (*statefile.File, error) {
+	stateData, err := readStateData(ctx, source, reader)
 	if err != nil {
 		return nil, err
 	}
@@ -89,14 +100,14 @@ type s3StateSource struct {
 	key    string
 }
 
-func readStateData(source string, reader s3ObjectReader) ([]byte, error) {
+func readStateData(ctx context.Context, source string, reader s3ObjectReader) ([]byte, error) {
 	s3Source, ok, err := parseS3StateSource(source)
 	if err != nil {
 		return nil, err
 	}
 
 	if ok {
-		return reader(context.Background(), s3Source.bucket, s3Source.key)
+		return reader(ctx, s3Source.bucket, s3Source.key)
 	}
 
 	return os.ReadFile(source)

--- a/test/acc_test.go
+++ b/test/acc_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	testUtil "github.com/chenrui333/terradozer/internal/awstools/test"
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	testUtil "github.com/chenrui333/terradozer/internal/awstools/test"
 	"github.com/onsi/gomega/gexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +25,7 @@ const (
 Terraform destroy using only the state - no *.tf files needed.
 
 USAGE:
-  $ terradozer [flags] <path/to/terraform.tfstate>
+  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
 
 FLAGS:
   -debug


### PR DESCRIPTION
## Summary

- support reading Terraform state directly from `s3://bucket/key` sources
- update CLI/README usage to document local or S3 state inputs
- clear static AWS credential fields from per-profile provider pool configs

Closes #48

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for reading Terraform state from S3 (s3://bucket/key) with a 30s, context-aware read timeout. Hardened AWS credential handling and error messages so state reads use the intended profile/region and never expose embedded credentials. Implements #48.

- **New Features**
  - Read state from `s3://bucket/key` via `github.com/aws/aws-sdk-go-v2`; local files still work.
  - S3 reads use a 30s default timeout and honor context; CLI help and README updated for S3 usage.

- **Bug Fixes**
  - Validate and sanitize S3 paths: require bucket and key; reject embedded credentials and query/fragment; redact credential-like input in errors.
  - Prevent unintended AWS credentials: do not default the profile before state read; provider configs set `access_key`, `secret_key`, and `token` to unknown values.

<sup>Written for commit ad2b948c3d20457eafef51eeb1d5154d2cc9eeb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for reading Terraform state from S3 URIs (s3://bucket/key) as well as local files; CLI usage and help updated.

* **Bug Fixes**
  * Prevented unintended inheritance of AWS static credentials into provider configs.
  * State reads now use a timeout and preserve AWS profile/region handling order; error messages reference the state source.

* **Documentation**
  * README examples and usage syntax updated for S3 state sources.

* **Tests**
  * Added unit and acceptance tests covering S3 parsing, reading, context propagation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->