### PR TITLE
feat: add recursive state discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Happy (terra)dozing!
 * Using the `-force` flag (dangerous!), terradozer can run in an automated fashion without human interaction and approval,
   for example, as part of your CI pipeline
 * Read Terraform state from a local file or S3 path, i.e., `terradozer s3://bucket/path/to/terraform.tfstate`
-* **Planned** ([#49](https://github.com/chenrui333/terradozer/issues/49)):
-  A `-recursive` flag to delete resources of all states found under a given directory, i.e.,
-  `terradozer -recursive s3://bucket-with-states/`. This is especially helpful if
+* Use the `-recursive` flag to delete resources from all `.tfstate` files found under a local directory or S3 prefix,
+  i.e., `terradozer -recursive ./path/to/states` or `terradozer -recursive s3://bucket-with-states/`.
+  This is especially helpful if
   you orchestrate Terraform modules with [Terragrunt](https://github.com/gruntwork-io/terragrunt) and store all states
   under the same directory or in the same S3 bucket. This way, a complete Terragrunt project could be cleaned up in an
   automated fashion.
@@ -91,6 +91,10 @@ To delete all resources in a Terraform state file:
 
     terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
 
+To delete all resources in every `.tfstate` file under a local directory or S3 prefix:
+
+    terradozer -recursive [flags] <directory|s3://bucket/prefix/>
+
 To see all options, run `terradozer --help`. Provide credentials for the AWS account you want to read state from and destroy resources in via the usual [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), e.g.,
 `AWS_PROFILE=<myaccount>` and either `AWS_REGION=<myregion>` or `AWS_DEFAULT_REGION=<myregion>`.
 If `AWS_PROFILE` is unset, terradozer uses the `default` profile.
@@ -104,6 +108,7 @@ Terradozer expects a valid Terraform state JSON document (the same content forma
 
 - The file extension is not used for detection; parsing is content-based.
 - Common names like `terraform.tfstate`, `*.json`, and `*.tfstate.json` are all supported.
+- Recursive discovery intentionally includes only files or S3 objects ending in `.tfstate`.
 - The file must contain Terraform-managed resources in state format (unsupported or malformed JSON will fail to parse).
  
 ## How it works

--- a/README.md
+++ b/README.md
@@ -89,11 +89,15 @@ curl -sSfL https://raw.githubusercontent.com/chenrui333/terradozer/main/install.
 
 To delete all resources in a Terraform state file:
 
-    terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
+```bash
+terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
+```
 
 To delete all resources in every `.tfstate` file under a local directory or S3 prefix:
 
-    terradozer -recursive [flags] <directory|s3://bucket/prefix/>
+```bash
+terradozer -recursive [flags] <directory|s3://bucket/prefix/>
+```
 
 Remote state reads and recursive S3 discovery use `-state-timeout` (default `30s`). Increase it for large S3 prefixes
 or slow networks without changing the per-resource destroy `-timeout`.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ To delete all resources in every `.tfstate` file under a local directory or S3 p
 
     terradozer -recursive [flags] <directory|s3://bucket/prefix/>
 
+Remote state reads and recursive S3 discovery use `-state-timeout` (default `30s`). Increase it for large S3 prefixes
+or slow networks without changing the per-resource destroy `-timeout`.
+
 To see all options, run `terradozer --help`. Provide credentials for the AWS account you want to read state from and destroy resources in via the usual [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), e.g.,
 `AWS_PROFILE=<myaccount>` and either `AWS_REGION=<myregion>` or `AWS_DEFAULT_REGION=<myregion>`.
 If `AWS_PROFILE` is unset, terradozer uses the `default` profile.

--- a/main.go
+++ b/main.go
@@ -106,6 +106,13 @@ func mainExitCode() int {
 		return 1
 	}
 
+	if stateTimeoutDuration <= 0 {
+		fmt.Fprint(os.Stderr, color.RedString("Error: -state-timeout flag must be greater than 0\n"))
+		printHelp(flags)
+
+		return 1
+	}
+
 	if len(args) == 0 {
 		fmt.Fprint(os.Stderr, color.RedString("Error: path to Terraform state file expected\n"))
 		printHelp(flags)

--- a/main.go
+++ b/main.go
@@ -98,6 +98,13 @@ func mainExitCode() int {
 		return 1
 	}
 
+	if timeoutDuration <= 0 {
+		fmt.Fprint(os.Stderr, color.RedString("Error: -timeout flag must be greater than 0\n"))
+		printHelp(flags)
+
+		return 1
+	}
+
 	stateTimeoutDuration, err := time.ParseDuration(stateTimeout)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("Error: failed to parse state-timeout flag: %s\n", err))
@@ -115,6 +122,14 @@ func mainExitCode() int {
 
 	if len(args) == 0 {
 		fmt.Fprint(os.Stderr, color.RedString("Error: path to Terraform state file expected\n"))
+		printHelp(flags)
+
+		return 1
+	}
+
+	if len(args) > 1 {
+		fmt.Fprint(os.Stderr,
+			color.RedString("Error: exactly one path to Terraform state file or recursive source expected\n"))
 		printHelp(flags)
 
 		return 1

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func mainExitCode() int {
 	var force bool
 	var logDebug bool
 	var parallel int
+	var recursive bool
 	var timeout string
 	var version bool
 
@@ -48,6 +49,8 @@ func mainExitCode() int {
 	flags.BoolVar(&force, "force", false, "Destroy without asking for confirmation")
 	flags.BoolVar(&logDebug, "debug", false, "Enable debug logging")
 	flags.IntVar(&parallel, "parallel", 10, "Limit the number of concurrent destroy operations")
+	flags.BoolVar(&recursive, "recursive", false,
+		"Discover Terraform state files recursively under a local directory or S3 prefix")
 	flags.BoolVar(&version, "version", false, "Show application version")
 
 	_ = flags.Parse(os.Args[1:])
@@ -103,7 +106,14 @@ func mainExitCode() int {
 
 	setAWSRegionFromDefault()
 
-	tfstate, err := state.New(pathToState)
+	stateSources, err := resolveStateSources(pathToState, recursive)
+	if err != nil {
+		fmt.Fprint(os.Stderr, color.RedString("Error:️ failed to discover Terraform state files: %s\n", err))
+
+		return 1
+	}
+
+	loadedStates, err := loadStates(stateSources)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("Error:️ failed to read Terraform state file: %s\n", err))
 
@@ -111,11 +121,13 @@ func mainExitCode() int {
 	}
 
 	internal.LogTitle("reading state")
-	log.WithField("source", pathToState).Info(internal.Pad("using state"))
+	for _, loaded := range loadedStates {
+		log.WithField("source", loaded.source).Info(internal.Pad("using state"))
+	}
 
 	setAWSProfileToDefault()
 
-	providers, err := initProviders(tfstate.ProviderNames(), "~/.terradozer", timeoutDuration)
+	providers, err := initProviders(providerNamesFromLoadedStates(loadedStates), "~/.terradozer", timeoutDuration)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("\nError:️ failed to initialize Terraform providers: %s\n", err))
 
@@ -128,22 +140,18 @@ func mainExitCode() int {
 		}
 	}()
 
-	resources, err := tfstate.Resources(providers)
+	resourceGroups, resourcesWithUpdatedState, err := resourcesFromLoadedStates(loadedStates, providers, parallel)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("\nError:️ failed to get resources from Terraform state: %s\n", err))
 
 		return 1
 	}
 
-	resourcesWithUpdatedState := terraform.UpdateResources(resources, parallel)
-
 	if !force {
 		internal.LogTitle("showing resources that would be deleted (dry run)")
 
 		// always show the resources that would be affected before deleting anything
-		for _, r := range resourcesWithUpdatedState {
-			log.WithField("id", r.ID()).Warn(internal.Pad(r.Type()))
-		}
+		logResourcesToDelete(resourceGroups, recursive || len(stateSources) > 1)
 
 		if len(resourcesWithUpdatedState) == 0 {
 			internal.LogTitle("all resources have already been deleted")
@@ -168,6 +176,91 @@ func mainExitCode() int {
 	}
 
 	return 0
+}
+
+type loadedState struct {
+	source  string
+	tfstate *state.State
+}
+
+type stateResourceGroup struct {
+	source    string
+	resources []terraform.UpdatableResource
+}
+
+func resolveStateSources(source string, recursive bool) ([]string, error) {
+	if !recursive {
+		return []string{source}, nil
+	}
+
+	return state.DiscoverSources(source)
+}
+
+func loadStates(sources []string) ([]loadedState, error) {
+	loadedStates := []loadedState{}
+	for _, source := range sources {
+		tfstate, err := state.New(source)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", source, err)
+		}
+
+		loadedStates = append(loadedStates, loadedState{source: source, tfstate: tfstate})
+	}
+
+	return loadedStates, nil
+}
+
+func providerNamesFromLoadedStates(loadedStates []loadedState) []string {
+	providerNames := []string{}
+	seen := map[string]bool{}
+	for _, loaded := range loadedStates {
+		for _, providerName := range loaded.tfstate.ProviderNames() {
+			if seen[providerName] {
+				continue
+			}
+
+			seen[providerName] = true
+			providerNames = append(providerNames, providerName)
+		}
+	}
+
+	return providerNames
+}
+
+func resourcesFromLoadedStates(loadedStates []loadedState, providers map[string]*provider.TerraformProvider,
+	parallel int) ([]stateResourceGroup, []terraform.UpdatableResource, error) {
+	resourceGroups := []stateResourceGroup{}
+	allResources := []terraform.UpdatableResource{}
+	for _, loaded := range loadedStates {
+		resources, err := loaded.tfstate.Resources(providers)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", loaded.source, err)
+		}
+
+		updatedResources := terraform.UpdateResources(resources, parallel)
+		if len(updatedResources) == 0 {
+			continue
+		}
+
+		resourceGroups = append(resourceGroups, stateResourceGroup{
+			source:    loaded.source,
+			resources: updatedResources,
+		})
+		allResources = append(allResources, updatedResources...)
+	}
+
+	return resourceGroups, allResources, nil
+}
+
+func logResourcesToDelete(resourceGroups []stateResourceGroup, showSource bool) {
+	for _, group := range resourceGroups {
+		if showSource {
+			log.WithField("source", group.source).Info(internal.Pad("state"))
+		}
+		for _, r := range group.resources {
+			log.WithField("id", r.ID()).Warn(internal.Pad(r.Type()))
+		}
+	}
 }
 
 func convertToDestroyableResources(resources []terraform.UpdatableResource) []resource.DestroyableResource {
@@ -271,7 +364,7 @@ const help = `
 Terraform destroy using only the state - no *.tf files needed.
 
 USAGE:
-  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
+  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key|directory|s3://bucket/prefix/>
 
 FLAGS:
 `

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func mainExitCode() int {
 	var logDebug bool
 	var parallel int
 	var recursive bool
+	var stateTimeout string
 	var timeout string
 	var version bool
 
@@ -51,6 +52,8 @@ func mainExitCode() int {
 	flags.IntVar(&parallel, "parallel", 10, "Limit the number of concurrent destroy operations")
 	flags.BoolVar(&recursive, "recursive", false,
 		"Discover Terraform state files recursively under a local directory or S3 prefix")
+	flags.StringVar(&stateTimeout, "state-timeout", "30s",
+		"Amount of time to wait for state reads and recursive discovery")
 	flags.BoolVar(&version, "version", false, "Show application version")
 
 	_ = flags.Parse(os.Args[1:])
@@ -95,6 +98,14 @@ func mainExitCode() int {
 		return 1
 	}
 
+	stateTimeoutDuration, err := time.ParseDuration(stateTimeout)
+	if err != nil {
+		fmt.Fprint(os.Stderr, color.RedString("Error: failed to parse state-timeout flag: %s\n", err))
+		printHelp(flags)
+
+		return 1
+	}
+
 	if len(args) == 0 {
 		fmt.Fprint(os.Stderr, color.RedString("Error: path to Terraform state file expected\n"))
 		printHelp(flags)
@@ -106,14 +117,14 @@ func mainExitCode() int {
 
 	setAWSRegionFromDefault()
 
-	stateSources, err := resolveStateSources(pathToState, recursive)
+	stateSources, err := resolveStateSources(pathToState, recursive, stateTimeoutDuration)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("Error:️ failed to discover Terraform state files: %s\n", err))
 
 		return 1
 	}
 
-	loadedStates, err := loadStates(stateSources)
+	loadedStates, err := loadStates(stateSources, stateTimeoutDuration)
 	if err != nil {
 		fmt.Fprint(os.Stderr, color.RedString("Error:️ failed to read Terraform state file: %s\n", err))
 
@@ -188,18 +199,23 @@ type stateResourceGroup struct {
 	resources []terraform.UpdatableResource
 }
 
-func resolveStateSources(source string, recursive bool) ([]string, error) {
+func resolveStateSources(source string, recursive bool, stateTimeout time.Duration) ([]string, error) {
 	if !recursive {
 		return []string{source}, nil
 	}
 
-	return state.DiscoverSources(source)
+	ctx, cancel := context.WithTimeout(context.Background(), stateTimeout)
+	defer cancel()
+
+	return state.DiscoverSourcesWithContext(ctx, source)
 }
 
-func loadStates(sources []string) ([]loadedState, error) {
+func loadStates(sources []string, stateTimeout time.Duration) ([]loadedState, error) {
 	loadedStates := []loadedState{}
 	for _, source := range sources {
-		tfstate, err := state.New(source)
+		ctx, cancel := context.WithTimeout(context.Background(), stateTimeout)
+		tfstate, err := state.NewWithContext(ctx, source)
+		cancel()
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", source, err)
 		}
@@ -364,7 +380,8 @@ const help = `
 Terraform destroy using only the state - no *.tf files needed.
 
 USAGE:
-  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key|directory|s3://bucket/prefix/>
+  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
+  $ terradozer -recursive [flags] <directory|s3://bucket/prefix/>
 
 FLAGS:
 `

--- a/main_test.go
+++ b/main_test.go
@@ -113,6 +113,46 @@ func TestMainExitCodeRejectsInvalidParallel(t *testing.T) {
 	}
 }
 
+func TestMainExitCodeRejectsInvalidTimeout(t *testing.T) {
+	testCases := []struct {
+		name        string
+		timeout     string
+		expectedErr string
+	}{
+		{
+			name:        "malformed",
+			timeout:     "not-a-duration",
+			expectedErr: "failed to parse timeout flag",
+		},
+		{
+			name:        "zero",
+			timeout:     "0s",
+			expectedErr: "-timeout flag must be greater than 0",
+		},
+		{
+			name:        "negative",
+			timeout:     "-1s",
+			expectedErr: "-timeout flag must be greater than 0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalArgs := os.Args
+			os.Args = []string{"terradozer", "-timeout", tc.timeout, "terraform.tfstate"}
+			t.Cleanup(func() {
+				os.Args = originalArgs
+			})
+
+			stderr := captureStderr(t, func() {
+				assert.Equal(t, 1, mainExitCode())
+			})
+
+			assert.Contains(t, stderr, tc.expectedErr)
+		})
+	}
+}
+
 func TestMainExitCodeRejectsInvalidStateTimeout(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -149,6 +189,38 @@ func TestMainExitCodeRejectsInvalidStateTimeout(t *testing.T) {
 			})
 
 			assert.Contains(t, stderr, tc.expectedErr)
+		})
+	}
+}
+
+func TestMainExitCodeRejectsExtraPositionalArguments(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "single state",
+			args: []string{"terradozer", "one.tfstate", "two.tfstate"},
+		},
+		{
+			name: "recursive",
+			args: []string{"terradozer", "-recursive", "states", "other-states"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalArgs := os.Args
+			os.Args = tc.args
+			t.Cleanup(func() {
+				os.Args = originalArgs
+			})
+
+			stderr := captureStderr(t, func() {
+				assert.Equal(t, 1, mainExitCode())
+			})
+
+			assert.Contains(t, stderr, "exactly one path to Terraform state file or recursive source expected")
 		})
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -129,6 +130,23 @@ func TestMainExitCodeDoesNotDefaultProfileBeforeStateRead(t *testing.T) {
 	})
 
 	assert.Contains(t, stderr, "must not include query or fragment components")
+	assert.Empty(t, os.Getenv("AWS_PROFILE"))
+}
+
+func TestMainExitCodeRejectsInvalidRecursiveSourceBeforeProfileDefault(t *testing.T) {
+	t.Setenv("AWS_PROFILE", "")
+
+	originalArgs := os.Args
+	os.Args = []string{"terradozer", "-recursive", filepath.Join(t.TempDir(), "missing")}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	stderr := captureStderr(t, func() {
+		assert.Equal(t, 1, mainExitCode())
+	})
+
+	assert.Contains(t, stderr, "failed to discover Terraform state files")
 	assert.Empty(t, os.Getenv("AWS_PROFILE"))
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -114,17 +114,43 @@ func TestMainExitCodeRejectsInvalidParallel(t *testing.T) {
 }
 
 func TestMainExitCodeRejectsInvalidStateTimeout(t *testing.T) {
-	originalArgs := os.Args
-	os.Args = []string{"terradozer", "-state-timeout", "not-a-duration", "terraform.tfstate"}
-	t.Cleanup(func() {
-		os.Args = originalArgs
-	})
+	testCases := []struct {
+		name         string
+		stateTimeout string
+		expectedErr  string
+	}{
+		{
+			name:         "malformed",
+			stateTimeout: "not-a-duration",
+			expectedErr:  "failed to parse state-timeout flag",
+		},
+		{
+			name:         "zero",
+			stateTimeout: "0s",
+			expectedErr:  "-state-timeout flag must be greater than 0",
+		},
+		{
+			name:         "negative",
+			stateTimeout: "-1s",
+			expectedErr:  "-state-timeout flag must be greater than 0",
+		},
+	}
 
-	stderr := captureStderr(t, func() {
-		assert.Equal(t, 1, mainExitCode())
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalArgs := os.Args
+			os.Args = []string{"terradozer", "-state-timeout", tc.stateTimeout, "terraform.tfstate"}
+			t.Cleanup(func() {
+				os.Args = originalArgs
+			})
 
-	assert.Contains(t, stderr, "failed to parse state-timeout flag")
+			stderr := captureStderr(t, func() {
+				assert.Equal(t, 1, mainExitCode())
+			})
+
+			assert.Contains(t, stderr, tc.expectedErr)
+		})
+	}
 }
 
 func TestMainExitCodeDoesNotDefaultProfileBeforeStateRead(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -113,6 +113,20 @@ func TestMainExitCodeRejectsInvalidParallel(t *testing.T) {
 	}
 }
 
+func TestMainExitCodeRejectsInvalidStateTimeout(t *testing.T) {
+	originalArgs := os.Args
+	os.Args = []string{"terradozer", "-state-timeout", "not-a-duration", "terraform.tfstate"}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	stderr := captureStderr(t, func() {
+		assert.Equal(t, 1, mainExitCode())
+	})
+
+	assert.Contains(t, stderr, "failed to parse state-timeout flag")
+}
+
 func TestMainExitCodeDoesNotDefaultProfileBeforeStateRead(t *testing.T) {
 	t.Setenv("AWS_ACCESS_KEY_ID", "access-key")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret-key")

--- a/pkg/state/discovery_test.go
+++ b/pkg/state/discovery_test.go
@@ -1,0 +1,219 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverSourcesFindsLocalTFStateFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	first := writeTestFile(t, tmpDir, "a/one.tfstate")
+	second := writeTestFile(t, tmpDir, "b/two.tfstate")
+	writeTestFile(t, tmpDir, "b/two.tfstate.backup")
+	writeTestFile(t, tmpDir, "c/state.json")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "d", "directory.tfstate"), 0o755))
+
+	actual, err := DiscoverSources(tmpDir)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{first, second}, actual)
+}
+
+func TestDiscoverSourcesRejectsInvalidLocalRecursiveSources(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile := writeTestFile(t, tmpDir, "terraform.tfstate")
+	emptyDir := filepath.Join(tmpDir, "empty")
+	require.NoError(t, os.Mkdir(emptyDir, 0o755))
+
+	tests := []struct {
+		name        string
+		source      string
+		expectedErr string
+	}{
+		{
+			name:        "missing path",
+			source:      filepath.Join(tmpDir, "missing"),
+			expectedErr: "no such file or directory",
+		},
+		{
+			name:        "file path",
+			source:      stateFile,
+			expectedErr: "must be a directory",
+		},
+		{
+			name:        "no matches",
+			source:      emptyDir,
+			expectedErr: "no Terraform state files found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := DiscoverSources(tc.source)
+
+			require.Error(t, err)
+			assert.Nil(t, actual)
+			assert.Contains(t, err.Error(), tc.expectedErr)
+		})
+	}
+}
+
+func TestDiscoverSourcesFindsS3TFStateObjects(t *testing.T) {
+	tests := []struct {
+		name           string
+		source         string
+		expectedBucket string
+		expectedPrefix string
+		expected       []string
+	}{
+		{
+			name:           "bucket root",
+			source:         "s3://state-bucket",
+			expectedBucket: "state-bucket",
+			expectedPrefix: "",
+			expected: []string{
+				"s3://state-bucket/a.tfstate",
+				"s3://state-bucket/nested/b.tfstate",
+				"s3://state-bucket/z.tfstate",
+			},
+		},
+		{
+			name:           "prefix without trailing slash",
+			source:         "s3://state-bucket/path/to/states",
+			expectedBucket: "state-bucket",
+			expectedPrefix: "path/to/states/",
+			expected: []string{
+				"s3://state-bucket/path/to/states/a.tfstate",
+				"s3://state-bucket/path/to/states/nested/b.tfstate",
+			},
+		},
+		{
+			name:           "prefix with trailing slash",
+			source:         "s3://state-bucket/path/to/states/",
+			expectedBucket: "state-bucket",
+			expectedPrefix: "path/to/states/",
+			expected: []string{
+				"s3://state-bucket/path/to/states/a.tfstate",
+				"s3://state-bucket/path/to/states/nested/b.tfstate",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := discoverSourcesWithS3ObjectLister(context.Background(), tc.source,
+				func(ctx context.Context, bucket, prefix string) ([]string, error) {
+					assert.Equal(t, tc.expectedBucket, bucket)
+					assert.Equal(t, tc.expectedPrefix, prefix)
+
+					return []string{
+						prefix + "nested/b.tfstate",
+						prefix + "skip.txt",
+						prefix + "a.tfstate",
+						prefix + "terraform.tfstate.backup",
+						"z.tfstate",
+					}, nil
+				})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestDiscoverSourcesReturnsS3ListErrors(t *testing.T) {
+	actual, err := discoverSourcesWithS3ObjectLister(context.Background(), "s3://state-bucket/path/",
+		func(ctx context.Context, bucket, prefix string) ([]string, error) {
+			return nil, errors.New("access denied")
+		})
+
+	require.Error(t, err)
+	assert.Nil(t, actual)
+	assert.Contains(t, err.Error(), "access denied")
+}
+
+func TestDiscoverSourcesReturnsS3ContextErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	actual, err := discoverSourcesWithS3ObjectLister(ctx, "s3://state-bucket/path/",
+		func(ctx context.Context, bucket, prefix string) ([]string, error) {
+			return nil, ctx.Err()
+		})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, actual)
+}
+
+func TestDiscoverSourcesRejectsInvalidS3RecursiveSources(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      string
+		expectedErr string
+	}{
+		{
+			name:        "missing bucket",
+			source:      "s3:///path/to/states/",
+			expectedErr: "must include a bucket",
+		},
+		{
+			name:        "embedded credentials",
+			source:      "s3://access:secret@state-bucket/path/to/states/",
+			expectedErr: "must not include embedded credentials",
+		},
+		{
+			name:        "query component",
+			source:      "s3://state-bucket/path/to/states/?versionId=123",
+			expectedErr: "must not include query or fragment",
+		},
+		{
+			name:        "fragment component",
+			source:      "s3://state-bucket/path/to/states/#version",
+			expectedErr: "must not include query or fragment",
+		},
+		{
+			name:        "malformed credentialed URI",
+			source:      "s3://access:secret@state-bucket/path%zz",
+			expectedErr: "must not include embedded credentials",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := DiscoverSourcesWithContext(context.Background(), tc.source)
+
+			require.Error(t, err)
+			assert.Nil(t, actual)
+			assert.Contains(t, err.Error(), tc.expectedErr)
+			assert.NotContains(t, err.Error(), "secret")
+		})
+	}
+}
+
+func TestDiscoverSourcesReturnsErrorWhenS3PrefixHasNoMatches(t *testing.T) {
+	actual, err := discoverSourcesWithS3ObjectLister(context.Background(), "s3://state-bucket/path/",
+		func(ctx context.Context, bucket, prefix string) ([]string, error) {
+			return []string{"path/state.json", "path/terraform.tfstate.backup"}, nil
+		})
+
+	require.Error(t, err)
+	assert.Nil(t, actual)
+	assert.Contains(t, err.Error(), "no Terraform state files found")
+}
+
+func writeTestFile(t *testing.T, baseDir, relPath string) string {
+	t.Helper()
+
+	path := filepath.Join(baseDir, filepath.FromSlash(relPath))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{}"), 0o644))
+
+	return path
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -39,6 +40,7 @@ type State struct {
 }
 
 type s3ObjectReader func(ctx context.Context, bucket, key string) ([]byte, error)
+type s3ObjectLister func(ctx context.Context, bucket, prefix string) ([]string, error)
 
 const defaultS3StateReadTimeout = 30 * time.Second
 
@@ -53,6 +55,32 @@ func New(source string) (*State, error) {
 // NewWithContext creates a state using the provided context for remote state reads.
 func NewWithContext(ctx context.Context, source string) (*State, error) {
 	return newWithS3ObjectReader(ctx, source, readS3ObjectFromAWS)
+}
+
+// DiscoverSources discovers Terraform state files under a local directory or S3 prefix.
+func DiscoverSources(source string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultS3StateReadTimeout)
+	defer cancel()
+
+	return DiscoverSourcesWithContext(ctx, source)
+}
+
+// DiscoverSourcesWithContext discovers Terraform state files using the provided context for remote listing.
+func DiscoverSourcesWithContext(ctx context.Context, source string) ([]string, error) {
+	return discoverSourcesWithS3ObjectLister(ctx, source, listS3StateObjectsFromAWS)
+}
+
+func discoverSourcesWithS3ObjectLister(ctx context.Context, source string, lister s3ObjectLister) ([]string, error) {
+	s3Prefix, ok, err := parseS3StatePrefix(source)
+	if err != nil {
+		return nil, err
+	}
+
+	if ok {
+		return discoverS3StateSources(ctx, source, s3Prefix, lister)
+	}
+
+	return discoverLocalStateSources(source)
 }
 
 func newWithS3ObjectReader(ctx context.Context, source string, reader s3ObjectReader) (*State, error) {
@@ -100,6 +128,11 @@ type s3StateSource struct {
 	key    string
 }
 
+type s3StatePrefix struct {
+	bucket string
+	prefix string
+}
+
 func readStateData(ctx context.Context, source string, reader s3ObjectReader) ([]byte, error) {
 	s3Source, ok, err := parseS3StateSource(source)
 	if err != nil {
@@ -114,29 +147,12 @@ func readStateData(ctx context.Context, source string, reader s3ObjectReader) ([
 }
 
 func parseS3StateSource(source string) (s3StateSource, bool, error) {
-	if !strings.HasPrefix(strings.ToLower(source), "s3://") {
-		return s3StateSource{}, false, nil
-	}
-
-	if s3SourceHasEmbeddedCredentials(source) {
-		return s3StateSource{}, true, errors.New("S3 state path must not include embedded credentials")
-	}
-
-	parsed, err := url.Parse(source)
+	parsed, ok, err := parseS3StateURL(source)
 	if err != nil {
-		return s3StateSource{}, true, fmt.Errorf("failed to parse S3 state path: %w", err)
+		return s3StateSource{}, ok, err
 	}
-
-	if parsed.User != nil {
-		return s3StateSource{}, true, errors.New("S3 state path must not include embedded credentials")
-	}
-
-	if parsed.Host == "" {
-		return s3StateSource{}, true, fmt.Errorf("S3 state path %q must include a bucket", source)
-	}
-
-	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return s3StateSource{}, true, fmt.Errorf("S3 state path %q must not include query or fragment components", source)
+	if !ok {
+		return s3StateSource{}, false, nil
 	}
 
 	key := strings.TrimPrefix(parsed.Path, "/")
@@ -147,6 +163,52 @@ func parseS3StateSource(source string) (s3StateSource, bool, error) {
 	return s3StateSource{bucket: parsed.Host, key: key}, true, nil
 }
 
+func parseS3StatePrefix(source string) (s3StatePrefix, bool, error) {
+	parsed, ok, err := parseS3StateURL(source)
+	if err != nil {
+		return s3StatePrefix{}, ok, err
+	}
+	if !ok {
+		return s3StatePrefix{}, false, nil
+	}
+
+	prefix := strings.TrimPrefix(parsed.Path, "/")
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	return s3StatePrefix{bucket: parsed.Host, prefix: prefix}, true, nil
+}
+
+func parseS3StateURL(source string) (*url.URL, bool, error) {
+	if !strings.HasPrefix(strings.ToLower(source), "s3://") {
+		return nil, false, nil
+	}
+
+	if s3SourceHasEmbeddedCredentials(source) {
+		return nil, true, errors.New("S3 state path must not include embedded credentials")
+	}
+
+	parsed, err := url.Parse(source)
+	if err != nil {
+		return nil, true, fmt.Errorf("failed to parse S3 state path: %w", err)
+	}
+
+	if parsed.User != nil {
+		return nil, true, errors.New("S3 state path must not include embedded credentials")
+	}
+
+	if parsed.Host == "" {
+		return nil, true, fmt.Errorf("S3 state path %q must include a bucket", source)
+	}
+
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, true, fmt.Errorf("S3 state path %q must not include query or fragment components", source)
+	}
+
+	return parsed, true, nil
+}
+
 func s3SourceHasEmbeddedCredentials(source string) bool {
 	remainder := source[len("s3://"):]
 	authorityEnd := strings.IndexAny(remainder, "/?#")
@@ -155,6 +217,74 @@ func s3SourceHasEmbeddedCredentials(source string) bool {
 	}
 
 	return strings.Contains(remainder[:authorityEnd], "@")
+}
+
+func discoverLocalStateSources(source string) ([]string, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("recursive state source %q must be a directory", source)
+	}
+
+	sources := []string{}
+	err = filepath.WalkDir(source, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !entry.Type().IsRegular() {
+			return nil
+		}
+		if strings.HasSuffix(entry.Name(), ".tfstate") {
+			sources = append(sources, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(sources)
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("no Terraform state files found under %q", source)
+	}
+
+	return sources, nil
+}
+
+func discoverS3StateSources(ctx context.Context, source string, s3Prefix s3StatePrefix,
+	lister s3ObjectLister) ([]string, error) {
+	keys, err := lister(ctx, s3Prefix.bucket, s3Prefix.prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	sources := []string{}
+	for _, key := range keys {
+		if !strings.HasPrefix(key, s3Prefix.prefix) {
+			continue
+		}
+		if strings.HasSuffix(key, ".tfstate") {
+			sources = append(sources, s3StateSourceURI(s3Prefix.bucket, key))
+		}
+	}
+
+	sort.Strings(sources)
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("no Terraform state files found under %q", source)
+	}
+
+	return sources, nil
+}
+
+func s3StateSourceURI(bucket, key string) string {
+	return (&url.URL{
+		Scheme: "s3",
+		Host:   bucket,
+		Path:   "/" + key,
+	}).String()
 }
 
 func readS3ObjectFromAWS(ctx context.Context, bucket, key string) ([]byte, error) {
@@ -187,6 +317,35 @@ func readS3ObjectFromAWS(ctx context.Context, bucket, key string) ([]byte, error
 	}
 
 	return stateData, nil
+}
+
+func listS3StateObjectsFromAWS(ctx context.Context, bucket, prefix string) ([]string, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	client := s3.NewFromConfig(cfg)
+	paginator := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	keys := []string{}
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list s3://%s/%s: %w", bucket, prefix, err)
+		}
+
+		for _, object := range page.Contents {
+			if object.Key != nil {
+				keys = append(keys, *object.Key)
+			}
+		}
+	}
+
+	return keys, nil
 }
 
 func readStateFile(stateData []byte) (*statefile.File, error) {

--- a/test/acc_test.go
+++ b/test/acc_test.go
@@ -25,7 +25,7 @@ const (
 Terraform destroy using only the state - no *.tf files needed.
 
 USAGE:
-  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
+  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key|directory|s3://bucket/prefix/>
 
 FLAGS:
   -debug
@@ -36,6 +36,8 @@ FLAGS:
     	Destroy without asking for confirmation
   -parallel int
     	Limit the number of concurrent destroy operations (default 10)
+  -recursive
+` + "    \tDiscover Terraform state files recursively under a local directory or S3 prefix\n" + `
   -timeout string
     	Amount of time to wait for a destroy of a resource to finish (default "30s")
   -version

--- a/test/acc_test.go
+++ b/test/acc_test.go
@@ -25,7 +25,8 @@ const (
 Terraform destroy using only the state - no *.tf files needed.
 
 USAGE:
-  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key|directory|s3://bucket/prefix/>
+  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
+  $ terradozer -recursive [flags] <directory|s3://bucket/prefix/>
 
 FLAGS:
   -debug
@@ -38,10 +39,12 @@ FLAGS:
     	Limit the number of concurrent destroy operations (default 10)
   -recursive
 ` + "    \tDiscover Terraform state files recursively under a local directory or S3 prefix\n" + `
+  -state-timeout string
+` + "    \tAmount of time to wait for state reads and recursive discovery (default \"30s\")\n" + `
   -timeout string
-    	Amount of time to wait for a destroy of a resource to finish (default "30s")
+` + "    \tAmount of time to wait for a destroy of a resource to finish (default \"30s\")\n" + `
   -version
-    	Show application version
+` + "    \tShow application version\n" + `
 `
 )
 

--- a/test/acc_test.go
+++ b/test/acc_test.go
@@ -21,31 +21,30 @@ import (
 
 const (
 	packagePath  = "github.com/chenrui333/terradozer"
-	usageMessage = `
-Terraform destroy using only the state - no *.tf files needed.
-
-USAGE:
-  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>
-  $ terradozer -recursive [flags] <directory|s3://bucket/prefix/>
-
-FLAGS:
-  -debug
-    	Enable debug logging
-  -dry-run
-    	Show what would be destroyed
-  -force
-    	Destroy without asking for confirmation
-  -parallel int
-    	Limit the number of concurrent destroy operations (default 10)
-  -recursive
-` + "    \tDiscover Terraform state files recursively under a local directory or S3 prefix\n" + `
-  -state-timeout string
-` + "    \tAmount of time to wait for state reads and recursive discovery (default \"30s\")\n" + `
-  -timeout string
-` + "    \tAmount of time to wait for a destroy of a resource to finish (default \"30s\")\n" + `
-  -version
-` + "    \tShow application version\n" + `
-`
+	usageMessage = "\n" +
+		"Terraform destroy using only the state - no *.tf files needed.\n" +
+		"\n" +
+		"USAGE:\n" +
+		"  $ terradozer [flags] <path/to/terraform.tfstate|s3://bucket/key>\n" +
+		"  $ terradozer -recursive [flags] <directory|s3://bucket/prefix/>\n" +
+		"\n" +
+		"FLAGS:\n" +
+		"  -debug\n" +
+		"    \tEnable debug logging\n" +
+		"  -dry-run\n" +
+		"    \tShow what would be destroyed\n" +
+		"  -force\n" +
+		"    \tDestroy without asking for confirmation\n" +
+		"  -parallel int\n" +
+		"    \tLimit the number of concurrent destroy operations (default 10)\n" +
+		"  -recursive\n" +
+		"    \tDiscover Terraform state files recursively under a local directory or S3 prefix\n" +
+		"  -state-timeout string\n" +
+		"    \tAmount of time to wait for state reads and recursive discovery (default \"30s\")\n" +
+		"  -timeout string\n" +
+		"    \tAmount of time to wait for a destroy of a resource to finish (default \"30s\")\n" +
+		"  -version\n" +
+		"    \tShow application version\n"
 )
 
 func TestAcc_ConfirmDeletion(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `-recursive` mode for local directories and S3 prefixes
- discover only `*.tfstate` files deterministically before reading states
- load all discovered states before provider init/deletion and show resources grouped by state
- update README/help text and add focused discovery/CLI tests

## References

Closes #49

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add recursive state discovery with `-recursive` to delete resources across all `.tfstate` files under a directory or S3 prefix. Adds `-state-timeout` for remote state reads and recursive S3 listing, and improves CLI validation and errors.

- **New Features**
  - Added `-recursive` for directories and S3 prefixes (e.g., `terradozer -recursive ./states` or `terradozer -recursive s3://bucket/prefix/`).
  - Added `-state-timeout` (default `30s`) for remote state reads and recursive S3 listing; independent of destroy `-timeout`.
  - Discovers only `.tfstate` files deterministically; loads all before provider init; dry-run groups resources by state.
  - Stricter S3 path validation with clear errors (no embedded credentials, bucket required, no query/fragment).

- **Bug Fixes**
  - Require exactly one positional argument; reject multiple sources; align acceptance usage output with `-recursive` and `-state-timeout`.
  - Validate `-timeout` and `-state-timeout` are > 0 with clear errors (including malformed durations).
  - Do not default `AWS_PROFILE` before state discovery and validation; failures do not modify env.

<sup>Written for commit 1a84dd5ab608e88114b5f76a8e63febeadbf1122. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added -recursive to discover/process multiple Terraform state files (local dir or s3://prefix); dry-run groups resources by source.
  * Added -state-timeout to control remote state reads and recursive discovery (default 30s); timeouts must be positive.

* **Bug Fixes**
  * CLI now validates timeout flags and requires a single input path; invalid recursive sources produce clearer errors.

* **Documentation**
  * README and help updated with recursive usage examples and note that discovery only includes .tfstate files.

* **Tests**
  * Added coverage for recursive discovery, S3/local cases, and timeout/input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->