### PR TITLE
fix: add API Gateway destroy priority chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.1 - 2026-05-28
+
+### Fixed
+
+- Add API Gateway destroy priority chain to prevent stage deletion failures caused by method_settings dependency ordering.
+
 ## v0.3.0 - 2026-05-04
 
 ### Added

--- a/pkg/resource/destroy.go
+++ b/pkg/resource/destroy.go
@@ -184,6 +184,15 @@ func destroyPriorityByType() map[string]int {
 		"aws_s3_bucket_policy":     10,
 		"aws_s3_bucket_versioning": 10,
 		"aws_s3_bucket":            20,
+
+		// API Gateway chain.
+		"aws_api_gateway_method_settings": 10,
+		"aws_api_gateway_integration":     15,
+		"aws_api_gateway_method":          15,
+		"aws_api_gateway_stage":           20,
+		"aws_api_gateway_deployment":      25,
+		"aws_api_gateway_resource":        30,
+		"aws_api_gateway_rest_api":        40,
 	}
 }
 


### PR DESCRIPTION
API Gateway resources had no destroy priority ordering, causing parallel deletion attempts that fail when `aws_api_gateway_stage` is destroyed before `aws_api_gateway_method_settings` (which holds a reference to the stage).

## Changes

Add API Gateway chain to `destroyPriorityByType()`:

| Priority | Resource Type |
|----------|--------------|
| 10 | `aws_api_gateway_method_settings` |
| 15 | `aws_api_gateway_integration` |
| 15 | `aws_api_gateway_method` |
| 20 | `aws_api_gateway_stage` |
| 25 | `aws_api_gateway_deployment` |
| 30 | `aws_api_gateway_resource` |
| 40 | `aws_api_gateway_rest_api` |

## Context

Hit this while destroying a `verify-company-lambda-api-gateway` module via TFE — the stage delete failed because method_settings was still referencing it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added destroy priority ordering for AWS API Gateway resources to prevent parallel deletion errors (e.g., stage removed before method settings). Resources now destroy in a safe, dependency-aware order.

- Bug Fixes
  - Added API Gateway ordering in `destroyPriorityByType()` to respect references.
  - Order: `aws_api_gateway_method_settings` (10) → `aws_api_gateway_integration` (15) / `aws_api_gateway_method` (15) → `aws_api_gateway_stage` (20) → `aws_api_gateway_deployment` (25) → `aws_api_gateway_resource` (30) → `aws_api_gateway_rest_api` (40).

<sup>Written for commit 49ae373c7bc5a2761bd758249bbcdab14da1237e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terradozer/pull/54?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API Gateway stage deletion failures that occurred when removing API Gateway infrastructure. A proper deletion sequence has been implemented for all API Gateway resource types including method settings, integrations, methods, stages, deployments, and resources. This ensures stages can be successfully deleted without encountering dependency-related errors during cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terradozer/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->